### PR TITLE
Replace confusing error message with direct instructions

### DIFF
--- a/environment/environment.py
+++ b/environment/environment.py
@@ -3,7 +3,10 @@ import re
 import subprocess
 import sys
 
-from conda.cli.python_api import Commands, run_command
+try:
+    from conda.cli.python_api import Commands, run_command
+except ImportError:
+    sys.exit('Please run the script from (base) conda environment')
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from utils import execute_process

--- a/server/server.py
+++ b/server/server.py
@@ -31,6 +31,8 @@ class OmnisciServer:
         columnar_output=None,
         lazy_fetch=None,
     ):  # default values of max_session_duration=43200 idle_session_duration=60
+        if not os.path.isdir(omnisci_executable) and not os.access(omnisci_executable, os.X_OK):
+            raise ValueError('Invalid omnisci executable given: ' + omnisci_executable)
         self.omnisci_executable = omnisci_executable
         self.server_port = omnisci_port
         self.user = user


### PR DESCRIPTION
Before the change, running `python run_ibis_tests.py -h` from outside conda environment or _not_ from the `base` environment lead to cryptic error message like
```
Traceback (most recent call last):                                                       
  File "run_ibis_tests.py", line 5, in <module>                                          
    from environment import CondaEnvironment                                             
  File "omniscripts/environment/__init__.py", line 1, in <module>    
    from .environment import CondaEnvironment                                            
  File "omniscripts/environment/environment.py", line 6, in <module> 
    from conda.cli.python_api import Commands, run_command                               
ModuleNotFoundError: No module named 'conda'                                             
```
Now it errors out saying `Please run the script from (base) conda environment`.

Also add some validation for `omnisci_executable`.