### PR TITLE
Add Mortgage to benchmarks

### DIFF
--- a/mortgage/__init__.py
+++ b/mortgage/__init__.py
@@ -1,0 +1,1 @@
+from .mortgage_runner import run_benchmark

--- a/mortgage/mortgage_ibis.py
+++ b/mortgage/mortgage_ibis.py
@@ -2,191 +2,22 @@
 import sys
 import time
 from collections import OrderedDict
+from timeit import default_timer as timer
 
 import pandas as pd
 import numpy as np
-import xgboost as xgb
-
 import ibis
-import pymapd
 
-
-def _parse_dtyped_csv(fname, dtypes, **kw):
-    all_but_dates = {col: valtype for (col, valtype) in dtypes.items()
-                     if valtype != 'datetime64'}
-    dates_only = [col for (col, valtype) in dtypes.items()
-                     if valtype == 'datetime64']
-
-    return pd.read_csv(fname, dtype=all_but_dates, parse_dates=dates_only, **kw)
-
-def cpu_load_acquisition_csv(acquisition_path, **kwargs):
-    """ Loads acquisition data
-
-    Returns
-    -------
-    GPU DataFrame
-    """
-    
-    cols = [
-        'loan_id', 'orig_channel', 'seller_name', 'orig_interest_rate', 'orig_upb', 'orig_loan_term', 
-        'orig_date', 'first_pay_date', 'orig_ltv', 'orig_cltv', 'num_borrowers', 'dti', 'borrower_credit_score', 
-        'first_home_buyer', 'loan_purpose', 'property_type', 'num_units', 'occupancy_status', 'property_state',
-        'zip', 'mortgage_insurance_percent', 'product_type', 'coborrow_credit_score', 'mortgage_insurance_type', 
-        'relocation_mortgage_indicator', 'year_quarter_ignore'
-    ]
-    
-    dtypes = OrderedDict([
-        ("loan_id", "int64"),
-        ("orig_channel", "category"),
-        ("seller_name", "category"),
-        ("orig_interest_rate", "float64"),
-        ("orig_upb", "int64"),
-        ("orig_loan_term", "int64"),
-        ("orig_date", "datetime64"),
-        ("first_pay_date", "datetime64"),
-        ("orig_ltv", "float64"),
-        ("orig_cltv", "float64"),
-        ("num_borrowers", "float64"),
-        ("dti", "float64"),
-        ("borrower_credit_score", "float64"),
-        ("first_home_buyer", "category"),
-        ("loan_purpose", "category"),
-        ("property_type", "category"),
-        ("num_units", "int64"),
-        ("occupancy_status", "category"),
-        ("property_state", "category"),
-        ("zip", "int64"),
-        ("mortgage_insurance_percent", "float64"),
-        ("product_type", "category"),
-        ("coborrow_credit_score", "float64"),
-        ("mortgage_insurance_type", "float64"),
-        ("relocation_mortgage_indicator", "category"),
-        ('year_quarter_ignore', 'int32')
-    ]) 
-    print(acquisition_path)
-    return _parse_dtyped_csv(acquisition_path, dtypes, names=cols, delimiter='|', index_col=False)
-
-def cpu_load_performance_csv(performance_path, **kwargs):
-    """ Loads performance data
-
-    Returns
-    -------
-    GPU DataFrame
-    """
-    
-    cols = [
-        "loan_id", "monthly_reporting_period", "servicer", "interest_rate", "current_actual_upb",
-        "loan_age", "remaining_months_to_legal_maturity", "adj_remaining_months_to_maturity",
-        "maturity_date", "msa", "current_loan_delinquency_status", "mod_flag", "zero_balance_code",
-        "zero_balance_effective_date", "last_paid_installment_date", "foreclosed_after",
-        "disposition_date", "foreclosure_costs", "prop_preservation_and_repair_costs",
-        "asset_recovery_costs", "misc_holding_expenses", "holding_taxes", "net_sale_proceeds",
-        "credit_enhancement_proceeds", "repurchase_make_whole_proceeds", "other_foreclosure_proceeds",
-        "non_interest_bearing_upb", "principal_forgiveness_upb", "repurchase_make_whole_proceeds_flag",
-        "foreclosure_principal_write_off_amount", "servicing_activity_indicator"
-    ]
-    
-    dtypes = OrderedDict([
-        ("loan_id", "int64"),
-        ("monthly_reporting_period", "datetime64"),
-        ("servicer", "category"),
-        ("interest_rate", "float64"),
-        ("current_actual_upb", "float64"),
-        ("loan_age", "float64"),
-        ("remaining_months_to_legal_maturity", "float64"),
-        ("adj_remaining_months_to_maturity", "float64"),
-        ("maturity_date", "datetime64"),
-        ("msa", "float64"),
-        ("current_loan_delinquency_status", "int32"),
-        ("mod_flag", "category"),
-        ("zero_balance_code", "category"),
-        ("zero_balance_effective_date", "datetime64"),
-        ("last_paid_installment_date", "datetime64"),
-        ("foreclosed_after", "datetime64"),
-        ("disposition_date", "datetime64"),
-        ("foreclosure_costs", "float64"),
-        ("prop_preservation_and_repair_costs", "float64"),
-        ("asset_recovery_costs", "float64"),
-        ("misc_holding_expenses", "float64"),
-        ("holding_taxes", "float64"),
-        ("net_sale_proceeds", "float64"),
-        ("credit_enhancement_proceeds", "float64"),
-        ("repurchase_make_whole_proceeds", "float64"),
-        ("other_foreclosure_proceeds", "float64"),
-        ("non_interest_bearing_upb", "float64"),
-        ("principal_forgiveness_upb", "float64"),
-        ("repurchase_make_whole_proceeds_flag", "category"),
-        ("foreclosure_principal_write_off_amount", "float64"),
-        ("servicing_activity_indicator", "category")
-    ])
-
-    print(performance_path)
-    
-    return _parse_dtyped_csv(performance_path, dtypes, names=cols, delimiter='|')
-
-#------------------------------------------------------------------------------------------
-DB_NAME = 'mortgage'
-
-#def make_conn(host='localhost', port=6274, user='admin', password='HyperInteractive', ipc=None):
-def make_conn(host='localhost', port=8000, user='admin', password='HyperInteractive', ipc=None):
-    _opts = dict(host=host, port=port, user=user, password=password, ipc=ipc)
-    conn = ibis.omniscidb.connect(**_opts)
-    conn._opts = _opts
-    return conn
-
-def make_db(conn, dbname=DB_NAME, recreate=True):
-    try:
-        db = conn.database(dbname)
-    except pymapd.exceptions.Error as e:
-        if 'does not exist' not in e.args[0]:
-            raise
-        # db doesn't exist, ignore
-        db = None
-    else:
-        # db exists, flush it to start from scratch
-        if recreate:
-            print('recreating %s db' % dbname)
-            conn.drop_database(dbname, force=True)
-            time.sleep(2)
-            conn = make_conn(**conn._opts)
-            db = None
-
-    if not db:
-        conn.create_database(dbname)
-        db = conn.database(dbname)
-    db._name = dbname
-
-    return db, conn
-
-def make_table(conn, database_name, table_name, schema_table):
-    if not conn.exists_table(name=table_name, database=database_name):
-        conn.create_table(table_name=table_name, schema=schema_table, database=database_name)
-    db, conn = make_db(conn, database_name, False)
-    table = db.table(table_name)
-    table._name = table_name
-    return table, conn
-
-#------------------------------------------------------------------------------------------
-'''
-def load_table(db, table_name, fpath, options=None):
-    cmd = "COPY %s FROM '%s'" % (table_name, fpath)
-    if options:
-        cmd = '%s WITH (%s)' % (cmd, ', '.join('%s=%s' % (k, v) for (k, v) in options.items()))
-    db._execute(cmd)
-'''
-
-def pd_load_table(conn, db, table_name, pd_df):
-    conn.load_data(table_name=table_name, obj=pd_df, database=db._name)
-    return db.table(table_name)
+from .mortgage_pandas import MortgagePandasBenchmark # used for loading
 
 class Timer:
     def __init__(self, name):
         self.name = name
     def __enter__(self):
-        self.start = time.time()
+        self.start = timer()
         return self
     def __exit__(self, *a, **kw):
-        print('%s took %.3f sec' % (self.name, time.time() - self.start))
+        print(f'[mortgage-timers] {self.name} took {timer() - self.start} sec')
 
 #------------------------------------------------------------------------------------------
 def create_joined_df(perf_table):
@@ -250,330 +81,76 @@ def join_perf_acq_gdfs(perf_df, acq_table):
                 resultCols.append(req[colName])
     return merged[resultCols]
 
-def import_data(conn, db, acq_table, perf_table,
-                      quarter=1, year=2000, perf_file="", **kwargs):
-    shmem_conn_opts = dict(conn._opts)
-    shmem_conn_opts['ipc'] = True
-    shmem_conn = make_conn(**shmem_conn_opts)
-    shmem_db, shmem_conn = make_db(shmem_conn, recreate=False)
-    #load_table(db, names_table._name, col_names_path)
-
-    # print('names.memory_usage')
-    # print(names.memory_usage(index=False))
-
-    with Timer('load acqiusition via pandas->ibis'):
-        pd_acq_df = cpu_load_acquisition_csv(acquisition_path='%s/Acquisition_%sQ%s.txt' % (acq_data_path, year, quarter))
-        with Timer('\tpandas->ibis acq import'):
-            acq_table = pd_load_table(shmem_conn, shmem_db, acq_table._name, pd_acq_df)
-        del pd_acq_df
-
-    #acq_df = acq_table.left_join(names_table, )
-    # print('acq_gdf.memory_usage')
-    # print(acq_gdf.memory_usage(index=False))
-
-    #acq_gdf = acq_gdf.merge(names, how='left', on=['seller_name'])
-    #acq_gdf = acq_gdf.drop(['seller_name'], axis=1)
-    #acq_gdf['seller_name'] = acq_gdf['new']
-    #acq_gdf = acq_gdf.drop(['new'], axis=1)
-
-    with Timer('load performance via pandas->ibis'):
-        pd_perf_df = cpu_load_performance_csv(perf_file)
-        with Timer('\tpandas->ibis perf import'):
-            perf_table = pd_load_table(shmem_conn, shmem_db, perf_table._name, pd_perf_df)
-        del pd_perf_df
-    
-    return acq_table, perf_table
-
-# vnlitvin: PoC
-
-def Query_execute(self, **kwargs):
-    # inlining omnisci cursor._fetch and hacking it; also hacking execute
-    with self.client._execute(
-        self.compiled_sql, results=True, **kwargs
-    ) as cur:
-        import pdb;pdb.set_trace()
-        result = cur.to_df()
-        result = self.schema().apply_to(result)
-
-    return result
-
-import pymapd._parsers as pymapd_parsers
-def pymapd_load_data(buf, schema, tdf=None):
-    """
-    Load a `pandas.DataFrame` from a buffer written to shared memory
-
-    Parameters
-    ----------
-    buf : pyarrow.Buffer
-    shcema : pyarrow.Schema
-    tdf(optional) : TDataFrame
-
-    Returns
-    -------
-    df : pandas.DataFrame
-    """
-    print("vnlitvin HACKED it")
-    message = pymapd_parsers.pa.read_message(buf)
-    rb = pymapd_parsers.pa.read_record_batch(message, schema)
-    df = rb #.to_pandas()
-    df.set_tdf = pymapd_parsers.MethodType(pymapd_parsers.set_tdf, df)
-    df.get_tdf = pymapd_parsers.MethodType(pymapd_parsers.get_tdf, df)
-    df.set_tdf(tdf)
-    return df
-
-# patching
-#ibis.client.Query.execute = Query_execute
-#pymapd_parsers._load_data = pymapd_load_data
-#import pymapd.connection
-#pymapd.connection._load_data = pymapd_load_data
-# /PoC
-
 def run_ibis_workflow(acq_table, perf_table):
-    with Timer('make ibis queries'):
+    with Timer('create ibis queries'):
         joined_df = create_joined_df(perf_table)
-
         mon12_df = create_12_mon_features(joined_df)
-        #del(testdf)
 
         perf_df = final_performance_delinquency(perf_table, mon12_df)
-        #del(gdf, joined_df)
-
         final_gdf = join_perf_acq_gdfs(perf_df, acq_table)
-        #del(perf_df)
-        #del(acq_gdf)
-
-        #final_gdf = last_mile_cleaning(final_gdf)
 
     with Timer('ibis compilation'):
-        tmp = final_gdf.compile()
-        #print(tmp)
-        tmp = final_gdf.materialize()
+        final_gdf.compile()
+        final_gdf.materialize()
 
     with Timer('execute queries'):
         result = final_gdf.execute()
     return result
 
+def _split_year_quarter(num):
+    return 2000 + num // 4, num % 4 + 1
 
-#------------------------------------------------------------------------------------------
-t_train = 0
-t_dmatrix = 0
+def etl_ibis(
+    dataset_path,
+    dfiles_num,
+    acq_schema,
+    perf_schema,
+    database_name,
+    table_prefix,
+    omnisci_server_worker,
+    delete_old_database,
+    create_new_table,
+    ipc_connection,
+    etl_keys,
+    import_mode,
+):
+    etl_times = {key: 0.0 for key in etl_keys}
 
-def train_xgb(pd_df):
-    global t_train, t_dmatrix
-    print('xgboost')
+    omnisci_server_worker.create_database(database_name, delete_if_exists=delete_old_database)
+    pdBench = MortgagePandasBenchmark(dataset_path, 'xgb') # used for loading
 
-    dxgb_cpu_params = {
-        'nround':            100,
-        'max_depth':         8,
-        'max_leaves':        2**8,
-        'alpha':             0.9,
-        'max_bin' : 256,
-        #'eta':               0.1,
-        #'gamma':             0.1,
-        'learning_rate':     0.1,
-        'subsample':         1,
-        'reg_lambda':        1,
-        'scale_pos_weight':  2,
-        'min_child_weight':  0,  #30
-        'tree_method':       'hist',
-        'predictor' : 'cpu_predictor',
-        #n_gpus':            1,
-        # 'distributed_dask':  True,
-        #'loss':              'ls',
-        #'objective':         'reg:linear',
-        #'max_features':      'auto',
-        #'criterion':         'friedman_mse',
-        #'grow_policy':       'lossguide',
-        #'verbose':           True
-    }
-
-    t0 = time.time() 
-    y = pd_df['delinquency_12']
-    t1 = time.time()
-    print('\tselecting 1 column: %s seconds' % (t1 - t0))
-    x = pd_df.drop(['delinquency_12'], axis=1)
-    print('\tdropping 1 column: %s seconds' % (time.time() - t1))
-    print('training_data_x.shape = ', x.shape)
-
-    dtrain = xgb.DMatrix(x, y)
-    t_dmatrix += time.time() - t0
-
-    t0 = time.time()
-    print('xgboost training temporarily disabled to save benchmarking time')
-    model_xgb = None #xgb.train(dxgb_cpu_params, dtrain, num_boost_round=dxgb_cpu_params['nround'])
-    t_train += time.time() - t0
-    
-    return model_xgb
-
-# to download data for this script,
-# visit https://rapidsai.github.io/demos/datasets/mortgage-data
-# and update the following paths accordingly
-
-if len(sys.argv) < 3:
-    raise ValueError("needed to point path to mortgage folder, "
-                     "count quarter to process")
-else:
-    mortgage_path = sys.argv[1]
-    count_quarter_processing = int(sys.argv[2])
-    #ml_fw = sys.argv[3]
-    
-acq_data_path = mortgage_path + "/acq"
-perf_data_path = mortgage_path + "/perf"
-col_names_path = mortgage_path + "/names.csv"
-
-from pathlib import Path
-
-def main():
-    # end_year = 2016 # end_year is inclusive
-    # part_count = 16 # the number of data files to train against
-    # gpu_time = 0
-    usePandas = '--use-pandas' in sys.argv
-
-    socketCon = make_conn()
-    db, socketCon = make_db(socketCon)
-
-    shmemCon = make_conn(ipc=True)
-    shDb, shmemCon = make_db(shmemCon, recreate=False)
-
-    '''
-    t0 = time.time()
-    tmp1 = socketCon.create_table_from_csv('temp_perf', '/localdisk/vnlitvin/mortgage-fsi/perf/Performance_2000Q1.txt', ibis.Schema(
-        names=("loan_id", "monthly_reporting_period", "servicer", "interest_rate", "current_actual_upb",
-               "loan_age", "remaining_months_to_legal_maturity", "adj_remaining_months_to_maturity",
-               "maturity_date", "msa", "current_loan_delinquency_status", "mod_flag", "zero_balance_code",
-               "zero_balance_effective_date", "last_paid_installment_date", "foreclosed_after",
-               "disposition_date", "foreclosure_costs", "prop_preservation_and_repair_costs",
-               "asset_recovery_costs", "misc_holding_expenses", "holding_taxes", "net_sale_proceeds",
-               "credit_enhancement_proceeds", "repurchase_make_whole_proceeds", "other_foreclosure_proceeds",
-               "non_interest_bearing_upb", "principal_forgiveness_upb", "repurchase_make_whole_proceeds_flag",
-               "foreclosure_principal_write_off_amount", "servicing_activity_indicator"),
-        types=('int64', 'timestamp', 'category', 'float64', 'float64',
-               'float64', 'float64', 'float64',
-               'timestamp', 'float64', 'int32', 'category', 'category',
-               'timestamp', 'timestamp', 'timestamp',
-               'timestamp', 'float64', 'float64',
-               'float64', 'float64', 'float64', 'float64',
-               'float64', 'float64', 'float64',
-               'float64', 'float64', 'category',
-               'float64', 'category')
-    ), DB_NAME)
-    print('temp storage load: %s' % (time.time() - t0))
-
-    return 0
-    '''
-
-    ACQ_SCHEMA = ibis.Schema(
-        names=('loan_id', 'orig_channel', 'seller_name', 'orig_interest_rate', 'orig_upb', 'orig_loan_term',
-               'orig_date', 'first_pay_date', 'orig_ltv', 'orig_cltv', 'num_borrowers', 'dti', 'borrower_credit_score',
-               'first_home_buyer', 'loan_purpose', 'property_type', 'num_units', 'occupancy_status', 'property_state',
-               'zip', 'mortgage_insurance_percent', 'product_type', 'coborrow_credit_score', 'mortgage_insurance_type',
-               'relocation_mortgage_indicator', 'year_quarter_ignore'),
-        types=('int64', 'category', 'string', 'float64', 'int64', 'int64',
-               'timestamp', 'timestamp', 'float64', 'float64', 'float64', 'float64', 'float64',
-               'category', 'category', 'category', 'int64', 'category', 'category',
-               'int64', 'float64', 'category', 'float64', 'float64',
-               'category', 'int32')
-    )
-    PERF_SCHEMA = ibis.Schema(
-        names=("loan_id", "monthly_reporting_period", "servicer", "interest_rate", "current_actual_upb",
-               "loan_age", "remaining_months_to_legal_maturity", "adj_remaining_months_to_maturity",
-               "maturity_date", "msa", "current_loan_delinquency_status", "mod_flag", "zero_balance_code",
-               "zero_balance_effective_date", "last_paid_installment_date", "foreclosed_after",
-               "disposition_date", "foreclosure_costs", "prop_preservation_and_repair_costs",
-               "asset_recovery_costs", "misc_holding_expenses", "holding_taxes", "net_sale_proceeds",
-               "credit_enhancement_proceeds", "repurchase_make_whole_proceeds", "other_foreclosure_proceeds",
-               "non_interest_bearing_upb", "principal_forgiveness_upb", "repurchase_make_whole_proceeds_flag",
-               "foreclosure_principal_write_off_amount", "servicing_activity_indicator"),
-        types=('int64', 'timestamp', 'category', 'float64', 'float64',
-               'float64', 'float64', 'float64',
-               'timestamp', 'float64', 'int32', 'category', 'category',
-               'timestamp', 'timestamp', 'timestamp',
-               'timestamp', 'float64', 'float64',
-               'float64', 'float64', 'float64', 'float64',
-               'float64', 'float64', 'float64',
-               'float64', 'float64', 'category',
-               'float64', 'category')
-    )
-
-    #names_table, con = make_table(con, DB_NAME, 'names', ibis.Schema(
-    #    names=('seller_name', 'new'), types=('string', 'string')
-    #))
-    if usePandas:
-        acq_table, con = make_table(socketCon, DB_NAME, 'acq', ACQ_SCHEMA)
-        perf_table, con = make_table(socketCon, DB_NAME, 'perf', PERF_SCHEMA)
-
-
-    global t_train, t_dmatrix
-
-    pd_dfs = []
-    perf_format_path = perf_data_path + "/Performance_%sQ%s.txt"
-
-    time_ETL = time.time()
-    for quarter in range(0, count_quarter_processing):
-        year = 2000 + quarter // 4
-        #perf_file = perf_format_path % (str(year), str(quarter % 4 + 1))
-
-        files = [f for f in Path(perf_data_path).iterdir() if f.match('Performance_%sQ%s.txt*' % (str(year), str(quarter % 4 + 1)))]
-        # print(files)
-        for f in files:
-            # print(f)
-            if usePandas:
-                acq_table, perf_table = import_data(socketCon, db, acq_table, perf_table, year=year, quarter=(quarter % 4 + 1), perf_file=str(f))
-            #if not skipLoad:
-            #    acq_table, perf_table = import_data(con, db, acq_table, perf_table, year=year, quarter=(quarter % 4 + 1), perf_file=str(f))
-            else:
-                with Timer('load acquisition'):
-                    socketCon.create_table_from_csv('tmp_acq', '%s/Acquisition_%sQ%s.txt' % (acq_data_path, year, quarter % 4 + 1), ACQ_SCHEMA, DB_NAME, delimiter=',', header='true', fragment_size=2000000)
-                #    acq_table = socketCon.table('tmp_acq')
-                #with Timer('transform acquisition'):
-                #    socketCon.create_table('acq', acq_table, database=DB_NAME)
-                #    socketCon.drop_table('tmp_acq')
-                with Timer('load performance'):
-                    socketCon.create_table_from_csv('tmp_perf', f, PERF_SCHEMA, DB_NAME, delimiter=',', header=True, fragment_size=2000000)
-                #    perf_table = socketCon.table('tmp_perf')
-                #with Timer('transform performance'):
-                #    socketCon.create_table('perf', perf_table, database=DB_NAME)
-                #    socketCon.drop_table('tmp_perf')
-                
-
-                acq_table = shDb.table('tmp_acq')
-                perf_table = shDb.table('tmp_perf')
-
-            pd_dfs.append(
-                run_ibis_workflow(acq_table, perf_table)
+    # Create table and import data
+    if create_new_table:
+        t0 = timer()
+        if import_mode == "copy-from":
+            raise ValueError("COPY FROM does not work with Mortgage dataset")
+        elif import_mode == "pandas":
+            raise NotImplementedError("Loading mortgage for ibis by Pandas not implemented yet")
+        elif import_mode == "fsi":
+            year, quarter = _split_year_quarter(dfiles_num)
+            omnisci_server_worker._conn.create_table_from_csv(
+                f'{table_prefix}_acq',
+                f'{pdBench.acq_data_path}/Acquisition_{year}Q{quarter}.txt',
+                acq_schema, database_name, delimiter=',', header='true', fragment_size=2000000
             )
-            #if not usePandas:
-            #    socketCon.drop_table('tmp_acq')
-            #    socketCon.drop_table('tmp_perf')
-            # print('finish f = ', f)
+            omnisci_server_worker._conn.create_table_from_csv(
+                f'{table_prefix}_perf', 
+                f'{pdBench.perf_data_path}/Performance_{year}Q{quarter}.txt',
+                perf_schema, database_name, delimiter=',', header=True, fragment_size=2000000
+            )
+        etl_times["t_readcsv"] = round((timer() - t0) * 1000)
 
-    time_ETL_end = time.time()
+    # Second connection - this is ibis's ipc connection for DML
+    omnisci_server_worker.connect_to_server(database_name, ipc=ipc_connection)
+    acq_table = omnisci_server_worker.database(database_name).table(f'{table_prefix}_acq')
+    perf_table = omnisci_server_worker.database(database_name).table(f'{table_prefix}_perf')
 
-    print("ETL time: ", time_ETL_end - time_ETL)
+    t_etl_start = timer()
+    ibis_df = run_ibis_workflow(acq_table, perf_table)
+    with Timer('splitting columns by Pandas for ML'):
+            y = ibis_df['delinquency_12']
+            x = ibis_df.drop(['delinquency_12'], axis=1)
 
-    ##########################################################################
-    print('pd_dfs.len = ', len(pd_dfs))
-    #return
+    etl_times["t_etl"] = round((timer() - t_etl_start) * 1000)
 
-    #pd_df = pd_dfs[0]
-
-    #one quarter at a time
-    all_df = pd.concat(pd_dfs)
-
-    print("concat df shape:", all_df.shape)
-
-    #for pd_df in pd_dfs:
-    #    ml_func(pd_df)
-
-    train_xgb(all_df)    
-    #train_xgb(pd_dfs[0])
-    print('t_train = ', t_train)
-    print('t_dmatrix = ', t_dmatrix)
-
-    time_ML_train_end = time.time()
-    print("Machine learning - train: ", time_ML_train_end - time_ETL_end)
-
-
-
-if __name__ == '__main__':
-    main()
+    return ibis_df, x, y, etl_times

--- a/mortgage/mortgage_ibis.py
+++ b/mortgage/mortgage_ibis.py
@@ -144,10 +144,6 @@ def etl_ibis(
 
     t_etl_start = timer()
     ibis_df = run_ibis_workflow(acq_table, perf_table)
-    with Timer('splitting columns by Pandas for ML'):
-            y = ibis_df['delinquency_12']
-            x = ibis_df.drop(['delinquency_12'], axis=1)
-
     etl_times["t_etl"] = round((timer() - t_etl_start) * 1000)
 
-    return ibis_df, x, y, mb, etl_times
+    return ibis_df, mb, etl_times

--- a/mortgage/mortgage_ibis.py
+++ b/mortgage/mortgage_ibis.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+import sys
+import time
+from collections import OrderedDict
+
+import pandas as pd
+import numpy as np
+import xgboost as xgb
+
+import ibis
+import pymapd
+
+
+def _parse_dtyped_csv(fname, dtypes, **kw):
+    all_but_dates = {col: valtype for (col, valtype) in dtypes.items()
+                     if valtype != 'datetime64'}
+    dates_only = [col for (col, valtype) in dtypes.items()
+                     if valtype == 'datetime64']
+
+    return pd.read_csv(fname, dtype=all_but_dates, parse_dates=dates_only, **kw)
+
+def cpu_load_acquisition_csv(acquisition_path, **kwargs):
+    """ Loads acquisition data
+
+    Returns
+    -------
+    GPU DataFrame
+    """
+    
+    cols = [
+        'loan_id', 'orig_channel', 'seller_name', 'orig_interest_rate', 'orig_upb', 'orig_loan_term', 
+        'orig_date', 'first_pay_date', 'orig_ltv', 'orig_cltv', 'num_borrowers', 'dti', 'borrower_credit_score', 
+        'first_home_buyer', 'loan_purpose', 'property_type', 'num_units', 'occupancy_status', 'property_state',
+        'zip', 'mortgage_insurance_percent', 'product_type', 'coborrow_credit_score', 'mortgage_insurance_type', 
+        'relocation_mortgage_indicator', 'year_quarter_ignore'
+    ]
+    
+    dtypes = OrderedDict([
+        ("loan_id", "int64"),
+        ("orig_channel", "category"),
+        ("seller_name", "category"),
+        ("orig_interest_rate", "float64"),
+        ("orig_upb", "int64"),
+        ("orig_loan_term", "int64"),
+        ("orig_date", "datetime64"),
+        ("first_pay_date", "datetime64"),
+        ("orig_ltv", "float64"),
+        ("orig_cltv", "float64"),
+        ("num_borrowers", "float64"),
+        ("dti", "float64"),
+        ("borrower_credit_score", "float64"),
+        ("first_home_buyer", "category"),
+        ("loan_purpose", "category"),
+        ("property_type", "category"),
+        ("num_units", "int64"),
+        ("occupancy_status", "category"),
+        ("property_state", "category"),
+        ("zip", "int64"),
+        ("mortgage_insurance_percent", "float64"),
+        ("product_type", "category"),
+        ("coborrow_credit_score", "float64"),
+        ("mortgage_insurance_type", "float64"),
+        ("relocation_mortgage_indicator", "category"),
+        ('year_quarter_ignore', 'int32')
+    ]) 
+    print(acquisition_path)
+    return _parse_dtyped_csv(acquisition_path, dtypes, names=cols, delimiter='|', index_col=False)
+
+def cpu_load_performance_csv(performance_path, **kwargs):
+    """ Loads performance data
+
+    Returns
+    -------
+    GPU DataFrame
+    """
+    
+    cols = [
+        "loan_id", "monthly_reporting_period", "servicer", "interest_rate", "current_actual_upb",
+        "loan_age", "remaining_months_to_legal_maturity", "adj_remaining_months_to_maturity",
+        "maturity_date", "msa", "current_loan_delinquency_status", "mod_flag", "zero_balance_code",
+        "zero_balance_effective_date", "last_paid_installment_date", "foreclosed_after",
+        "disposition_date", "foreclosure_costs", "prop_preservation_and_repair_costs",
+        "asset_recovery_costs", "misc_holding_expenses", "holding_taxes", "net_sale_proceeds",
+        "credit_enhancement_proceeds", "repurchase_make_whole_proceeds", "other_foreclosure_proceeds",
+        "non_interest_bearing_upb", "principal_forgiveness_upb", "repurchase_make_whole_proceeds_flag",
+        "foreclosure_principal_write_off_amount", "servicing_activity_indicator"
+    ]
+    
+    dtypes = OrderedDict([
+        ("loan_id", "int64"),
+        ("monthly_reporting_period", "datetime64"),
+        ("servicer", "category"),
+        ("interest_rate", "float64"),
+        ("current_actual_upb", "float64"),
+        ("loan_age", "float64"),
+        ("remaining_months_to_legal_maturity", "float64"),
+        ("adj_remaining_months_to_maturity", "float64"),
+        ("maturity_date", "datetime64"),
+        ("msa", "float64"),
+        ("current_loan_delinquency_status", "int32"),
+        ("mod_flag", "category"),
+        ("zero_balance_code", "category"),
+        ("zero_balance_effective_date", "datetime64"),
+        ("last_paid_installment_date", "datetime64"),
+        ("foreclosed_after", "datetime64"),
+        ("disposition_date", "datetime64"),
+        ("foreclosure_costs", "float64"),
+        ("prop_preservation_and_repair_costs", "float64"),
+        ("asset_recovery_costs", "float64"),
+        ("misc_holding_expenses", "float64"),
+        ("holding_taxes", "float64"),
+        ("net_sale_proceeds", "float64"),
+        ("credit_enhancement_proceeds", "float64"),
+        ("repurchase_make_whole_proceeds", "float64"),
+        ("other_foreclosure_proceeds", "float64"),
+        ("non_interest_bearing_upb", "float64"),
+        ("principal_forgiveness_upb", "float64"),
+        ("repurchase_make_whole_proceeds_flag", "category"),
+        ("foreclosure_principal_write_off_amount", "float64"),
+        ("servicing_activity_indicator", "category")
+    ])
+
+    print(performance_path)
+    
+    return _parse_dtyped_csv(performance_path, dtypes, names=cols, delimiter='|')
+
+#------------------------------------------------------------------------------------------
+DB_NAME = 'mortgage'
+
+#def make_conn(host='localhost', port=6274, user='admin', password='HyperInteractive', ipc=None):
+def make_conn(host='localhost', port=8000, user='admin', password='HyperInteractive', ipc=None):
+    _opts = dict(host=host, port=port, user=user, password=password, ipc=ipc)
+    conn = ibis.omniscidb.connect(**_opts)
+    conn._opts = _opts
+    return conn
+
+def make_db(conn, dbname=DB_NAME, recreate=True):
+    try:
+        db = conn.database(dbname)
+    except pymapd.exceptions.Error as e:
+        if 'does not exist' not in e.args[0]:
+            raise
+        # db doesn't exist, ignore
+        db = None
+    else:
+        # db exists, flush it to start from scratch
+        if recreate:
+            print('recreating %s db' % dbname)
+            conn.drop_database(dbname, force=True)
+            time.sleep(2)
+            conn = make_conn(**conn._opts)
+            db = None
+
+    if not db:
+        conn.create_database(dbname)
+        db = conn.database(dbname)
+    db._name = dbname
+
+    return db, conn
+
+def make_table(conn, database_name, table_name, schema_table):
+    if not conn.exists_table(name=table_name, database=database_name):
+        conn.create_table(table_name=table_name, schema=schema_table, database=database_name)
+    db, conn = make_db(conn, database_name, False)
+    table = db.table(table_name)
+    table._name = table_name
+    return table, conn
+
+#------------------------------------------------------------------------------------------
+'''
+def load_table(db, table_name, fpath, options=None):
+    cmd = "COPY %s FROM '%s'" % (table_name, fpath)
+    if options:
+        cmd = '%s WITH (%s)' % (cmd, ', '.join('%s=%s' % (k, v) for (k, v) in options.items()))
+    db._execute(cmd)
+'''
+
+def pd_load_table(conn, db, table_name, pd_df):
+    conn.load_data(table_name=table_name, obj=pd_df, database=db._name)
+    return db.table(table_name)
+
+class Timer:
+    def __init__(self, name):
+        self.name = name
+    def __enter__(self):
+        self.start = time.time()
+        return self
+    def __exit__(self, *a, **kw):
+        print('%s took %.3f sec' % (self.name, time.time() - self.start))
+
+#------------------------------------------------------------------------------------------
+def create_joined_df(perf_table):
+    delinquency_12_expr = ibis.case().when(perf_table['current_loan_delinquency_status'].notnull(),
+                                           perf_table['current_loan_delinquency_status']).else_(-1).end()
+    upb_12_expr = ibis.case().when(perf_table['current_actual_upb'].notnull(),
+                                   perf_table['current_actual_upb']).else_(999999999).end()
+    joined_df = perf_table['loan_id',
+                        perf_table['monthly_reporting_period'].month().name('timestamp_month').cast('int32'),
+                        perf_table['monthly_reporting_period'].year().name('timestamp_year').cast('int32'),
+                        delinquency_12_expr.name('delinquency_12'),
+                        upb_12_expr.name('upb_12')]
+    return joined_df
+
+def create_12_mon_features(joined_df):
+    delinq_df = None
+    n_months = 1 # should be 12 but we don't have UNION yet :(
+    for y in range(1, n_months + 1):
+        year_dec = ibis.case().when(joined_df['timestamp_month'] < ibis.literal(y), 1).else_(0).end()
+        tmp_df = joined_df['loan_id', 'delinquency_12', 'upb_12',
+                           (joined_df['timestamp_year'] - year_dec).name('timestamp_year')]
+
+        delinquency_12 = (tmp_df['delinquency_12'].max() > 3).cast('int32') + (tmp_df['upb_12'].min() == 0).cast('int32')
+        tmp_df = tmp_df.groupby(['loan_id', 'timestamp_year']).aggregate(delinquency_12.name('delinquency_12'))
+
+        tmp_df = tmp_df.mutate(timestamp_month=ibis.literal(y, 'int32'))
+
+        if delinq_df is None:
+            delinq_df = tmp_df
+        else:
+            delinq_df = delinq_df.union(tmp_df)
+
+    return delinq_df
+
+def final_performance_delinquency(perf_table, mon12_df):
+    # rename columns, or join fails because it has overlapping keys
+    return perf_table.left_join(mon12_df.relabel({'loan_id': 'mon12_loan_id'}), [('loan_id', 'mon12_loan_id'),
+                                            perf_table['monthly_reporting_period'].month().cast('int32') == mon12_df['timestamp_month'],
+                                            perf_table['monthly_reporting_period'].year().cast('int32') == mon12_df['timestamp_year']])[perf_table, mon12_df['delinquency_12']]
+
+
+def join_perf_acq_gdfs(perf_df, acq_table):
+    merged = perf_df.inner_join(acq_table, ['loan_id'])
+
+    dropList = {
+        'loan_id', 'orig_date', 'first_pay_date', 'seller_name',
+        'monthly_reporting_period', 'last_paid_installment_date', 'maturity_date', 'ever_30', 'ever_90', 'ever_180',
+        'delinquency_30', 'delinquency_90', 'delinquency_180', 'upb_12',
+        'zero_balance_effective_date','foreclosed_after', 'disposition_date','timestamp'
+    }
+
+    resultCols = []
+    for req in (perf_df, acq_table):
+        schema = req.schema()
+        for colName in schema:
+            if colName in dropList:
+                continue
+            if isinstance(schema[colName], ibis.expr.datatypes.Category):
+                resultCols.append(req[colName].cast('int32'))
+            else:
+                resultCols.append(req[colName])
+    return merged[resultCols]
+
+def import_data(conn, db, acq_table, perf_table,
+                      quarter=1, year=2000, perf_file="", **kwargs):
+    shmem_conn_opts = dict(conn._opts)
+    shmem_conn_opts['ipc'] = True
+    shmem_conn = make_conn(**shmem_conn_opts)
+    shmem_db, shmem_conn = make_db(shmem_conn, recreate=False)
+    #load_table(db, names_table._name, col_names_path)
+
+    # print('names.memory_usage')
+    # print(names.memory_usage(index=False))
+
+    with Timer('load acqiusition via pandas->ibis'):
+        pd_acq_df = cpu_load_acquisition_csv(acquisition_path='%s/Acquisition_%sQ%s.txt' % (acq_data_path, year, quarter))
+        with Timer('\tpandas->ibis acq import'):
+            acq_table = pd_load_table(shmem_conn, shmem_db, acq_table._name, pd_acq_df)
+        del pd_acq_df
+
+    #acq_df = acq_table.left_join(names_table, )
+    # print('acq_gdf.memory_usage')
+    # print(acq_gdf.memory_usage(index=False))
+
+    #acq_gdf = acq_gdf.merge(names, how='left', on=['seller_name'])
+    #acq_gdf = acq_gdf.drop(['seller_name'], axis=1)
+    #acq_gdf['seller_name'] = acq_gdf['new']
+    #acq_gdf = acq_gdf.drop(['new'], axis=1)
+
+    with Timer('load performance via pandas->ibis'):
+        pd_perf_df = cpu_load_performance_csv(perf_file)
+        with Timer('\tpandas->ibis perf import'):
+            perf_table = pd_load_table(shmem_conn, shmem_db, perf_table._name, pd_perf_df)
+        del pd_perf_df
+    
+    return acq_table, perf_table
+
+# vnlitvin: PoC
+
+def Query_execute(self, **kwargs):
+    # inlining omnisci cursor._fetch and hacking it; also hacking execute
+    with self.client._execute(
+        self.compiled_sql, results=True, **kwargs
+    ) as cur:
+        import pdb;pdb.set_trace()
+        result = cur.to_df()
+        result = self.schema().apply_to(result)
+
+    return result
+
+import pymapd._parsers as pymapd_parsers
+def pymapd_load_data(buf, schema, tdf=None):
+    """
+    Load a `pandas.DataFrame` from a buffer written to shared memory
+
+    Parameters
+    ----------
+    buf : pyarrow.Buffer
+    shcema : pyarrow.Schema
+    tdf(optional) : TDataFrame
+
+    Returns
+    -------
+    df : pandas.DataFrame
+    """
+    print("vnlitvin HACKED it")
+    message = pymapd_parsers.pa.read_message(buf)
+    rb = pymapd_parsers.pa.read_record_batch(message, schema)
+    df = rb #.to_pandas()
+    df.set_tdf = pymapd_parsers.MethodType(pymapd_parsers.set_tdf, df)
+    df.get_tdf = pymapd_parsers.MethodType(pymapd_parsers.get_tdf, df)
+    df.set_tdf(tdf)
+    return df
+
+# patching
+#ibis.client.Query.execute = Query_execute
+#pymapd_parsers._load_data = pymapd_load_data
+#import pymapd.connection
+#pymapd.connection._load_data = pymapd_load_data
+# /PoC
+
+def run_ibis_workflow(acq_table, perf_table):
+    with Timer('make ibis queries'):
+        joined_df = create_joined_df(perf_table)
+
+        mon12_df = create_12_mon_features(joined_df)
+        #del(testdf)
+
+        perf_df = final_performance_delinquency(perf_table, mon12_df)
+        #del(gdf, joined_df)
+
+        final_gdf = join_perf_acq_gdfs(perf_df, acq_table)
+        #del(perf_df)
+        #del(acq_gdf)
+
+        #final_gdf = last_mile_cleaning(final_gdf)
+
+    with Timer('ibis compilation'):
+        tmp = final_gdf.compile()
+
+    with Timer('execute queries'):
+        result = final_gdf.execute()
+    return result
+
+
+#------------------------------------------------------------------------------------------
+t_train = 0
+t_dmatrix = 0
+
+def train_xgb(pd_df):
+    global t_train, t_dmatrix
+    print('xgboost')
+
+    dxgb_cpu_params = {
+        'nround':            100,
+        'max_depth':         8,
+        'max_leaves':        2**8,
+        'alpha':             0.9,
+        'max_bin' : 256,
+        #'eta':               0.1,
+        #'gamma':             0.1,
+        'learning_rate':     0.1,
+        'subsample':         1,
+        'reg_lambda':        1,
+        'scale_pos_weight':  2,
+        'min_child_weight':  0,  #30
+        'tree_method':       'hist',
+        'predictor' : 'cpu_predictor',
+        #n_gpus':            1,
+        # 'distributed_dask':  True,
+        #'loss':              'ls',
+        #'objective':         'reg:linear',
+        #'max_features':      'auto',
+        #'criterion':         'friedman_mse',
+        #'grow_policy':       'lossguide',
+        #'verbose':           True
+    }
+
+    t0 = time.time() 
+    y = pd_df['delinquency_12']
+    t1 = time.time()
+    print('\tselecting 1 column: %s seconds' % (t1 - t0))
+    x = pd_df.drop(['delinquency_12'], axis=1)
+    print('\tdropping 1 column: %s seconds' % (time.time() - t1))
+    print('training_data_x.shape = ', x.shape)
+
+    dtrain = xgb.DMatrix(x, y)
+    t_dmatrix += time.time() - t0
+
+    t0 = time.time()
+    print('xgboost training temporarily disabled to save benchmarking time')
+    model_xgb = None #xgb.train(dxgb_cpu_params, dtrain, num_boost_round=dxgb_cpu_params['nround'])
+    t_train += time.time() - t0
+    
+    return model_xgb
+
+# to download data for this script,
+# visit https://rapidsai.github.io/demos/datasets/mortgage-data
+# and update the following paths accordingly
+
+if len(sys.argv) < 3:
+    raise ValueError("needed to point path to mortgage folder, "
+                     "count quarter to process")
+else:
+    mortgage_path = sys.argv[1]
+    count_quarter_processing = int(sys.argv[2])
+    #ml_fw = sys.argv[3]
+    
+acq_data_path = mortgage_path + "/acq"
+perf_data_path = mortgage_path + "/perf"
+col_names_path = mortgage_path + "/names.csv"
+
+from pathlib import Path
+
+def main():
+    # end_year = 2016 # end_year is inclusive
+    # part_count = 16 # the number of data files to train against
+    # gpu_time = 0
+    usePandas = '--use-pandas' in sys.argv
+
+    socketCon = make_conn()
+    db, socketCon = make_db(socketCon)
+
+    shmemCon = make_conn(ipc=True)
+    shDb, shmemCon = make_db(shmemCon, recreate=False)
+
+    '''
+    t0 = time.time()
+    tmp1 = socketCon.create_table_from_csv('temp_perf', '/localdisk/vnlitvin/mortgage-fsi/perf/Performance_2000Q1.txt', ibis.Schema(
+        names=("loan_id", "monthly_reporting_period", "servicer", "interest_rate", "current_actual_upb",
+               "loan_age", "remaining_months_to_legal_maturity", "adj_remaining_months_to_maturity",
+               "maturity_date", "msa", "current_loan_delinquency_status", "mod_flag", "zero_balance_code",
+               "zero_balance_effective_date", "last_paid_installment_date", "foreclosed_after",
+               "disposition_date", "foreclosure_costs", "prop_preservation_and_repair_costs",
+               "asset_recovery_costs", "misc_holding_expenses", "holding_taxes", "net_sale_proceeds",
+               "credit_enhancement_proceeds", "repurchase_make_whole_proceeds", "other_foreclosure_proceeds",
+               "non_interest_bearing_upb", "principal_forgiveness_upb", "repurchase_make_whole_proceeds_flag",
+               "foreclosure_principal_write_off_amount", "servicing_activity_indicator"),
+        types=('int64', 'timestamp', 'category', 'float64', 'float64',
+               'float64', 'float64', 'float64',
+               'timestamp', 'float64', 'int32', 'category', 'category',
+               'timestamp', 'timestamp', 'timestamp',
+               'timestamp', 'float64', 'float64',
+               'float64', 'float64', 'float64', 'float64',
+               'float64', 'float64', 'float64',
+               'float64', 'float64', 'category',
+               'float64', 'category')
+    ), DB_NAME)
+    print('temp storage load: %s' % (time.time() - t0))
+
+    return 0
+    '''
+
+    ACQ_SCHEMA = ibis.Schema(
+        names=('loan_id', 'orig_channel', 'seller_name', 'orig_interest_rate', 'orig_upb', 'orig_loan_term',
+               'orig_date', 'first_pay_date', 'orig_ltv', 'orig_cltv', 'num_borrowers', 'dti', 'borrower_credit_score',
+               'first_home_buyer', 'loan_purpose', 'property_type', 'num_units', 'occupancy_status', 'property_state',
+               'zip', 'mortgage_insurance_percent', 'product_type', 'coborrow_credit_score', 'mortgage_insurance_type',
+               'relocation_mortgage_indicator', 'year_quarter_ignore'),
+        types=('int64', 'category', 'string', 'float64', 'int64', 'int64',
+               'timestamp', 'timestamp', 'float64', 'float64', 'float64', 'float64', 'float64',
+               'category', 'category', 'category', 'int64', 'category', 'category',
+               'int64', 'float64', 'category', 'float64', 'float64',
+               'category', 'int32')
+    )
+    PERF_SCHEMA = ibis.Schema(
+        names=("loan_id", "monthly_reporting_period", "servicer", "interest_rate", "current_actual_upb",
+               "loan_age", "remaining_months_to_legal_maturity", "adj_remaining_months_to_maturity",
+               "maturity_date", "msa", "current_loan_delinquency_status", "mod_flag", "zero_balance_code",
+               "zero_balance_effective_date", "last_paid_installment_date", "foreclosed_after",
+               "disposition_date", "foreclosure_costs", "prop_preservation_and_repair_costs",
+               "asset_recovery_costs", "misc_holding_expenses", "holding_taxes", "net_sale_proceeds",
+               "credit_enhancement_proceeds", "repurchase_make_whole_proceeds", "other_foreclosure_proceeds",
+               "non_interest_bearing_upb", "principal_forgiveness_upb", "repurchase_make_whole_proceeds_flag",
+               "foreclosure_principal_write_off_amount", "servicing_activity_indicator"),
+        types=('int64', 'timestamp', 'category', 'float64', 'float64',
+               'float64', 'float64', 'float64',
+               'timestamp', 'float64', 'int32', 'category', 'category',
+               'timestamp', 'timestamp', 'timestamp',
+               'timestamp', 'float64', 'float64',
+               'float64', 'float64', 'float64', 'float64',
+               'float64', 'float64', 'float64',
+               'float64', 'float64', 'category',
+               'float64', 'category')
+    )
+
+    #names_table, con = make_table(con, DB_NAME, 'names', ibis.Schema(
+    #    names=('seller_name', 'new'), types=('string', 'string')
+    #))
+    if usePandas:
+        acq_table, con = make_table(socketCon, DB_NAME, 'acq', ACQ_SCHEMA)
+        perf_table, con = make_table(socketCon, DB_NAME, 'perf', PERF_SCHEMA)
+
+
+    global t_train, t_dmatrix
+
+    pd_dfs = []
+    perf_format_path = perf_data_path + "/Performance_%sQ%s.txt"
+
+    time_ETL = time.time()
+    for quarter in range(0, count_quarter_processing):
+        year = 2000 + quarter // 4
+        #perf_file = perf_format_path % (str(year), str(quarter % 4 + 1))
+
+        files = [f for f in Path(perf_data_path).iterdir() if f.match('Performance_%sQ%s.txt*' % (str(year), str(quarter % 4 + 1)))]
+        # print(files)
+        for f in files:
+            # print(f)
+            if usePandas:
+                acq_table, perf_table = import_data(socketCon, db, acq_table, perf_table, year=year, quarter=(quarter % 4 + 1), perf_file=str(f))
+            #if not skipLoad:
+            #    acq_table, perf_table = import_data(con, db, acq_table, perf_table, year=year, quarter=(quarter % 4 + 1), perf_file=str(f))
+            else:
+                with Timer('load acquisition'):
+                    socketCon.create_table_from_csv('tmp_acq', '%s/Acquisition_%sQ%s.txt' % (acq_data_path, year, quarter % 4 + 1), ACQ_SCHEMA, DB_NAME)#, fragment_size=None)
+                #    acq_table = socketCon.table('tmp_acq')
+                #with Timer('transform acquisition'):
+                #    socketCon.create_table('acq', acq_table, database=DB_NAME)
+                #    socketCon.drop_table('tmp_acq')
+                with Timer('load performance'):
+                    socketCon.create_table_from_csv('tmp_perf', f, PERF_SCHEMA, DB_NAME)#, fragment_size=100000)
+                #    perf_table = socketCon.table('tmp_perf')
+                #with Timer('transform performance'):
+                #    socketCon.create_table('perf', perf_table, database=DB_NAME)
+                #    socketCon.drop_table('tmp_perf')
+                
+
+                acq_table = shDb.table('tmp_acq')
+                perf_table = shDb.table('tmp_perf')
+
+            pd_dfs.append(
+                run_ibis_workflow(acq_table, perf_table)
+            )
+            if not usePandas:
+                socketCon.drop_table('tmp_acq')
+                socketCon.drop_table('tmp_perf')
+            # print('finish f = ', f)
+
+    time_ETL_end = time.time()
+
+    print("ETL time: ", time_ETL_end - time_ETL)
+
+    ##########################################################################
+    print('pd_dfs.len = ', len(pd_dfs))
+
+    #pd_df = pd_dfs[0]
+
+    #one quarter at a time
+    all_df = pd.concat(pd_dfs)
+
+    print("concat df shape:", all_df.shape)
+
+    #for pd_df in pd_dfs:
+    #    ml_func(pd_df)
+
+    train_xgb(all_df)    
+    #train_xgb(pd_dfs[0])
+    print('t_train = ', t_train)
+    print('t_dmatrix = ', t_dmatrix)
+
+    time_ML_train_end = time.time()
+    print("Machine learning - train: ", time_ML_train_end - time_ETL_end)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/mortgage/mortgage_pandas.py
+++ b/mortgage/mortgage_pandas.py
@@ -99,7 +99,7 @@ class MortgagePandasBenchmark:
         }
         dates_only = [col for (col, valtype) in dtypes.items() if valtype.name == 'datetime64[ns]']
         t0 = timer()
-        df = pd.read_csv(fname, dtype=all_but_dates, parse_dates=dates_only, **kw)
+        df = pd.read_csv(fname, dtype=all_but_dates, parse_dates=dates_only, skiprows=1, delimiter=',', **kw)
         t1 = timer()
         self.t_read_csv += t1 - t0
         return df
@@ -108,14 +108,14 @@ class MortgagePandasBenchmark:
         cols = [name for (name, dtype) in perf_fields]
         dtypes = OrderedDict(perf_fields)
         print(performance_path)
-        return self._parse_dtyped_csv(performance_path, dtypes, names=cols, delimiter="|")
+        return self._parse_dtyped_csv(performance_path, dtypes, names=cols)
 
     def cpu_load_acquisition_csv(self, acquisition_path, acq_fields, **kwargs):
         cols = [name for (name, dtype) in acq_fields]
         dtypes = OrderedDict(acq_fields)
         print(acquisition_path)
         return self._parse_dtyped_csv(
-            acquisition_path, dtypes, names=cols, delimiter="|", index_col=False
+            acquisition_path, dtypes, names=cols, index_col=False
         )
 
     def pd_load_names(self, **kwargs):

--- a/mortgage/mortgage_pandas.py
+++ b/mortgage/mortgage_pandas.py
@@ -441,12 +441,12 @@ def ml(df, n_runs, mb, ml_keys, ml_score_keys):
     print("ML runs: ", n_runs)
     for i in range(n_runs):
         mb.train_xgb(df)
-        ml_times['t_train_test_split'] += mb.t_dmatrix
+        ml_times['t_dmatrix'] += mb.t_dmatrix
         ml_times['t_train'] += mb.t_train
         mse_values.append(mb.score_mse)
         cod_values.append(mb.score_cod)
 
-    ml_times["t_ml"] += ml_times["t_train"] + ml_times["t_inference"]
+    ml_times["t_ml"] += ml_times["t_train"] + ml_times["t_dmatrix"]
 
     ml_scores["mse_mean"] = sum(mse_values) / len(mse_values)
     ml_scores["cod_mean"] = sum(cod_values) / len(cod_values)

--- a/mortgage/mortgage_pandas.py
+++ b/mortgage/mortgage_pandas.py
@@ -443,7 +443,7 @@ class MortgagePandasBenchmark:
 
         return df
 
-    def train_daal(pd_df):
+    def train_daal(self, pd_df):
         import daal4py
 
         dxgb_daal_params = {
@@ -475,7 +475,7 @@ class MortgagePandasBenchmark:
         # print("TRAINING TIME:", default_timer()-t0)
         return train_result
 
-    def train_xgb(pd_df):
+    def train_xgb(self, pd_df):
         import xgboost as xgb
 
         dxgb_cpu_params = {
@@ -515,9 +515,11 @@ class MortgagePandasBenchmark:
 
         return model_xgb
 
+    @staticmethod
     def mse(y_test, y_pred):
         return ((y_test - y_pred) ** 2).mean()
 
+    @staticmethod
     def cod(y_test, y_pred):
         y_bar = y_test.mean()
         total = ((y_test - y_bar) ** 2).sum()

--- a/mortgage/mortgage_pandas.py
+++ b/mortgage/mortgage_pandas.py
@@ -404,7 +404,8 @@ class MortgagePandasBenchmark:
 
     @staticmethod
     def split_year_quarter(num):
-        return 2000 + num // 4, num % 4 + 1
+        # num starts with 1 for 2000Q1
+        return 2000 + num // 4, num % 4
 
 def etl_pandas(
     dataset_path,
@@ -428,7 +429,6 @@ def etl_pandas(
     print("  t_drop_cols = ", mb.t_drop_cols)
     print("  t_merge = ", mb.t_merge)
     print("  t_conv_dates = ", mb.t_conv_dates)
-    x, y = mb.split_cols(pd_df)
     etl_times["t_etl"] = round((mb.t_one_hot_encoding + mb.t_fillna + mb.t_drop_cols + mb.t_merge + mb.t_conv_dates) * 1000)
 
     return pd_df, mb, etl_times

--- a/mortgage/mortgage_pandas.py
+++ b/mortgage/mortgage_pandas.py
@@ -3,16 +3,19 @@ import os
 import sys
 from collections import OrderedDict
 from pathlib import Path
-from timeit import default_timer
+from timeit import default_timer as timer
+import glob
 
 import numpy as np
 
 
 class MortgagePandasBenchmark:
-    def __init__(self, mortgage_path, algo):
+    def __init__(self, mortgage_path, algo, acq_fields=None, perf_fields=None):
         self.acq_data_path = mortgage_path + "/acq"
         self.perf_data_path = mortgage_path + "/perf"
         self.col_names_path = mortgage_path + "/names.csv"
+        self.acq_fields = acq_fields
+        self.perf_fields = perf_fields
 
         self.t_one_hot_encoding = 0
         self.t_read_csv = 0
@@ -32,13 +35,13 @@ class MortgagePandasBenchmark:
     def null_workaround(self, df, **kwargs):
         for column, data_type in df.dtypes.items():
 
-            t0 = default_timer()
+            t0 = timer()
             if str(data_type) == "category":
                 df[column] = df[column].cat.codes
-            t1 = default_timer()
+            t1 = timer()
             self.t_one_hot_encoding += t1 - t0
 
-            t0 = default_timer()
+            t0 = timer()
             if str(data_type) in [
                 "int8",
                 "int16",
@@ -48,34 +51,32 @@ class MortgagePandasBenchmark:
                 "float64",
             ]:
                 df[column] = df[column].fillna(np.dtype(data_type).type(-1))
-            t1 = default_timer()
+            t1 = timer()
             self.t_fillna += t1 - t0
 
         return df
 
+    def list_perf_files(self, quarter=1, year=2000):
+        return glob.glob(f'{self.perf_data_path}/Performance_{year}Q{quarter}.txt*')
+
     def run_cpu_workflow(self, quarter=1, year=2000, perf_file="", **kwargs):
         names = self.pd_load_names()
         acq_gdf = self.cpu_load_acquisition_csv(
-            acquisition_path=self.acq_data_path
-            + "/Acquisition_"
-            + str(year)
-            + "Q"
-            + str(quarter)
-            + ".txt"
-        )
-        t0 = default_timer()
+            acquisition_path=f'{self.acq_data_path}/Acquisition_{year}Q{quarter}.txt',
+            acq_fields=self.acq_fields)
+        t0 = timer()
         acq_gdf = acq_gdf.merge(names, how="left", on=["seller_name"])
-        t1 = default_timer()
+        t1 = timer()
         self.t_merge += t1 - t0
 
-        t0 = default_timer()
+        t0 = timer()
         acq_gdf = acq_gdf.drop(["seller_name"], axis=1)
         acq_gdf["seller_name"] = acq_gdf["new"]
         acq_gdf = acq_gdf.drop(["new"], axis=1)
-        t1 = default_timer()
+        t1 = timer()
         self.t_drop_cols += t1 - t0
 
-        cdf = self.cpu_load_performance_csv(perf_file)
+        cdf = self.cpu_load_performance_csv(perf_file, self.perf_fields)
 
         joined_df = self.create_joined_df(cdf)
         df_features_12 = self.create_12_mon_features(joined_df)
@@ -94,146 +95,24 @@ class MortgagePandasBenchmark:
 
     def _parse_dtyped_csv(self, fname, dtypes, **kw):
         all_but_dates = {
-            col: valtype for (col, valtype) in dtypes.items() if valtype != "datetime64"
+            col: valtype for (col, valtype) in dtypes.items() if valtype.name != 'datetime64[ns]'
         }
-        dates_only = [col for (col, valtype) in dtypes.items() if valtype == "datetime64"]
-        t0 = default_timer()
+        dates_only = [col for (col, valtype) in dtypes.items() if valtype.name == 'datetime64[ns]']
+        t0 = timer()
         df = pd.read_csv(fname, dtype=all_but_dates, parse_dates=dates_only, **kw)
-        t1 = default_timer()
+        t1 = timer()
         self.t_read_csv += t1 - t0
         return df
 
-    def cpu_load_performance_csv(self, performance_path, **kwargs):
-        cols = [
-            "loan_id",
-            "monthly_reporting_period",
-            "servicer",
-            "interest_rate",
-            "current_actual_upb",
-            "loan_age",
-            "remaining_months_to_legal_maturity",
-            "adj_remaining_months_to_maturity",
-            "maturity_date",
-            "msa",
-            "current_loan_delinquency_status",
-            "mod_flag",
-            "zero_balance_code",
-            "zero_balance_effective_date",
-            "last_paid_installment_date",
-            "foreclosed_after",
-            "disposition_date",
-            "foreclosure_costs",
-            "prop_preservation_and_repair_costs",
-            "asset_recovery_costs",
-            "misc_holding_expenses",
-            "holding_taxes",
-            "net_sale_proceeds",
-            "credit_enhancement_proceeds",
-            "repurchase_make_whole_proceeds",
-            "other_foreclosure_proceeds",
-            "non_interest_bearing_upb",
-            "principal_forgiveness_upb",
-            "repurchase_make_whole_proceeds_flag",
-            "foreclosure_principal_write_off_amount",
-            "servicing_activity_indicator",
-        ]
-
-        dtypes = OrderedDict(
-            [
-                ("loan_id", "int64"),
-                ("monthly_reporting_period", "datetime64"),
-                ("servicer", "category"),
-                ("interest_rate", "float64"),
-                ("current_actual_upb", "float64"),
-                ("loan_age", "float64"),
-                ("remaining_months_to_legal_maturity", "float64"),
-                ("adj_remaining_months_to_maturity", "float64"),
-                ("maturity_date", "datetime64"),
-                ("msa", "float64"),
-                ("current_loan_delinquency_status", "int32"),
-                ("mod_flag", "category"),
-                ("zero_balance_code", "category"),
-                ("zero_balance_effective_date", "datetime64"),
-                ("last_paid_installment_date", "datetime64"),
-                ("foreclosed_after", "datetime64"),
-                ("disposition_date", "datetime64"),
-                ("foreclosure_costs", "float64"),
-                ("prop_preservation_and_repair_costs", "float64"),
-                ("asset_recovery_costs", "float64"),
-                ("misc_holding_expenses", "float64"),
-                ("holding_taxes", "float64"),
-                ("net_sale_proceeds", "float64"),
-                ("credit_enhancement_proceeds", "float64"),
-                ("repurchase_make_whole_proceeds", "float64"),
-                ("other_foreclosure_proceeds", "float64"),
-                ("non_interest_bearing_upb", "float64"),
-                ("principal_forgiveness_upb", "float64"),
-                ("repurchase_make_whole_proceeds_flag", "category"),
-                ("foreclosure_principal_write_off_amount", "float64"),
-                ("servicing_activity_indicator", "category"),
-            ]
-        )
-
+    def cpu_load_performance_csv(self, performance_path, perf_fields, **kwargs):
+        cols = [name for (name, dtype) in perf_fields]
+        dtypes = OrderedDict(perf_fields)
         print(performance_path)
         return self._parse_dtyped_csv(performance_path, dtypes, names=cols, delimiter="|")
 
-    def cpu_load_acquisition_csv(self, acquisition_path, **kwargs):
-        cols = [
-            "loan_id",
-            "orig_channel",
-            "seller_name",
-            "orig_interest_rate",
-            "orig_upb",
-            "orig_loan_term",
-            "orig_date",
-            "first_pay_date",
-            "orig_ltv",
-            "orig_cltv",
-            "num_borrowers",
-            "dti",
-            "borrower_credit_score",
-            "first_home_buyer",
-            "loan_purpose",
-            "property_type",
-            "num_units",
-            "occupancy_status",
-            "property_state",
-            "zip",
-            "mortgage_insurance_percent",
-            "product_type",
-            "coborrow_credit_score",
-            "mortgage_insurance_type",
-            "relocation_mortgage_indicator",
-        ]
-        dtypes = OrderedDict(
-            [
-                ("loan_id", "int64"),
-                ("orig_channel", "category"),
-                ("seller_name", "category"),
-                ("orig_interest_rate", "float64"),
-                ("orig_upb", "int64"),
-                ("orig_loan_term", "int64"),
-                ("orig_date", "datetime64"),
-                ("first_pay_date", "datetime64"),
-                ("orig_ltv", "float64"),
-                ("orig_cltv", "float64"),
-                ("num_borrowers", "float64"),
-                ("dti", "float64"),
-                ("borrower_credit_score", "float64"),
-                ("first_home_buyer", "category"),
-                ("loan_purpose", "category"),
-                ("property_type", "category"),
-                ("num_units", "int64"),
-                ("occupancy_status", "category"),
-                ("property_state", "category"),
-                ("zip", "int64"),
-                ("mortgage_insurance_percent", "float64"),
-                ("product_type", "category"),
-                ("coborrow_credit_score", "float64"),
-                ("mortgage_insurance_type", "float64"),
-                ("relocation_mortgage_indicator", "category"),
-            ]
-        )
+    def cpu_load_acquisition_csv(self, acquisition_path, acq_fields, **kwargs):
+        cols = [name for (name, dtype) in acq_fields]
+        dtypes = OrderedDict(acq_fields)
         print(acquisition_path)
         return self._parse_dtyped_csv(
             acquisition_path, dtypes, names=cols, delimiter="|", index_col=False
@@ -245,9 +124,9 @@ class MortgagePandasBenchmark:
         #     ("seller_name", "category"),
         #     ("new", "category"),
         # ])
-        t0 = default_timer()
+        t0 = timer()
         df = pd.read_csv(self.col_names_path, names=cols, delimiter="|")
-        t1 = default_timer()
+        t1 = timer()
         self.t_read_csv += t1 - t0
         return df
 
@@ -264,40 +143,40 @@ class MortgagePandasBenchmark:
         del gdf
         test["timestamp"] = test["monthly_reporting_period"]
 
-        t0 = default_timer()
+        t0 = timer()
         test = test.drop(["monthly_reporting_period"], axis=1)
-        t1 = default_timer()
+        t1 = timer()
         self.t_drop_cols += t1 - t0
 
-        t0 = default_timer()
+        t0 = timer()
         test["timestamp_month"] = test["timestamp"].dt.month
         test["timestamp_year"] = test["timestamp"].dt.year
-        t1 = default_timer()
+        t1 = timer()
         self.t_conv_dates += t1 - t0
         test["delinquency_12"] = test["current_loan_delinquency_status"]
 
-        t0 = default_timer()
+        t0 = timer()
         test = test.drop(["current_loan_delinquency_status"], axis=1)
-        t1 = default_timer()
+        t1 = timer()
         self.t_drop_cols += t1 - t0
 
         test["upb_12"] = test["current_actual_upb"]
 
-        t0 = default_timer()
+        t0 = timer()
         test = test.drop(["current_actual_upb"], axis=1)
-        t1 = default_timer()
+        t1 = timer()
         self.t_drop_cols += t1 - t0
 
-        t0 = default_timer()
+        t0 = timer()
         test["upb_12"] = test["upb_12"].fillna(999999999)
         test["delinquency_12"] = test["delinquency_12"].fillna(-1)
-        t1 = default_timer()
+        t1 = timer()
         self.t_fillna += t1 - t0
 
-        t0 = default_timer()
+        t0 = timer()
         test["timestamp_year"] = test["timestamp_year"].astype("int32")
         test["timestamp_month"] = test["timestamp_month"].astype("int32")
-        t1 = default_timer()
+        t1 = timer()
         self.t_conv_dates += t1 - t0
 
         return test
@@ -310,7 +189,7 @@ class MortgagePandasBenchmark:
                 :, ["loan_id", "timestamp_year", "timestamp_month", "delinquency_12", "upb_12",],
             ]
 
-            t0 = default_timer()
+            t0 = timer()
             tmpdf["josh_months"] = tmpdf["timestamp_year"] * 12 + tmpdf["timestamp_month"]
             tmpdf["josh_mody_n"] = np.floor(
                 (tmpdf["josh_months"].astype("float64") - 24000 - y) / 12
@@ -327,12 +206,12 @@ class MortgagePandasBenchmark:
                 ((tmpdf["josh_mody_n"] * n_months) + 24000 + (y - 1)) / 12
             ).astype("int16")
             tmpdf["timestamp_month"] = np.int8(y)
-            t1 = default_timer()
+            t1 = timer()
             self.t_conv_dates += t1 - t0
 
-            t0 = default_timer()
+            t0 = timer()
             tmpdf = tmpdf.drop(["josh_mody_n"], axis=1)
-            t1 = default_timer()
+            t1 = timer()
             self.t_drop_cols += t1 - t0
 
             testdfs.append(tmpdf)
@@ -342,23 +221,23 @@ class MortgagePandasBenchmark:
         return pd.concat(testdfs)
 
     def combine_joined_12_mon(self, joined_df, testdf, **kwargs):
-        t0 = default_timer()
+        t0 = timer()
         joined_df = joined_df.drop(["delinquency_12"], axis=1)
         joined_df = joined_df.drop(["upb_12"], axis=1)
-        t1 = default_timer()
+        t1 = timer()
         self.t_drop_cols += t1 - t0
 
-        t0 = default_timer()
+        t0 = timer()
         joined_df["timestamp_year"] = joined_df["timestamp_year"].astype("int16")
         joined_df["timestamp_month"] = joined_df["timestamp_month"].astype("int8")
-        t1 = default_timer()
+        t1 = timer()
         self.t_conv_dates += t1 - t0
 
-        t0 = default_timer()
+        t0 = timer()
         df = joined_df.merge(
             testdf, how="left", on=["loan_id", "timestamp_year", "timestamp_month"]
         )
-        t1 = default_timer()
+        t1 = timer()
         self.t_merge += t1 - t0
 
         return df
@@ -367,27 +246,27 @@ class MortgagePandasBenchmark:
         merged = self.null_workaround(gdf)
         joined_df = self.null_workaround(joined_df)
 
-        t0 = default_timer()
+        t0 = timer()
         joined_df["timestamp_month"] = joined_df["timestamp_month"].astype("int8")
         joined_df["timestamp_year"] = joined_df["timestamp_year"].astype("int16")
         merged["timestamp_month"] = merged["monthly_reporting_period"].dt.month
         merged["timestamp_month"] = merged["timestamp_month"].astype("int8")
         merged["timestamp_year"] = merged["monthly_reporting_period"].dt.year
         merged["timestamp_year"] = merged["timestamp_year"].astype("int16")
-        t1 = default_timer()
+        t1 = timer()
         self.t_conv_dates += t1 - t0
 
-        t0 = default_timer()
+        t0 = timer()
         merged = merged.merge(
             joined_df, how="left", on=["loan_id", "timestamp_year", "timestamp_month"]
         )
-        t1 = default_timer()
+        t1 = timer()
         self.t_merge += t1 - t0
 
-        t0 = default_timer()
+        t0 = timer()
         merged = merged.drop(["timestamp_year"], axis=1)
         merged = merged.drop(["timestamp_month"], axis=1)
-        t1 = default_timer()
+        t1 = timer()
         self.t_drop_cols += t1 - t0
 
         return merged
@@ -396,9 +275,9 @@ class MortgagePandasBenchmark:
         perf = self.null_workaround(perf)
         acq = self.null_workaround(acq)
 
-        t0 = default_timer()
+        t0 = timer()
         df = perf.merge(acq, how="left", on=["loan_id"])
-        t1 = default_timer()
+        t1 = timer()
         self.t_merge += t1 - t0
 
         return df
@@ -419,31 +298,31 @@ class MortgagePandasBenchmark:
             "timestamp",
         ]
 
-        t0 = default_timer()
+        t0 = timer()
         for column in drop_list:
             df = df.drop([column], axis=1)
-        t1 = default_timer()
+        t1 = timer()
         self.t_drop_cols += t1 - t0
 
-        t0 = default_timer()
+        t0 = timer()
         for col, dtype in df.dtypes.iteritems():
             if str(dtype) == "category":
                 df[col] = df[col].cat.codes
-        t1 = default_timer()
+        t1 = timer()
         self.t_one_hot_encoding += t1 - t0
 
         df["delinquency_12"] = df["delinquency_12"] > 0
 
-        t0 = default_timer()
+        t0 = timer()
         df["delinquency_12"] = df["delinquency_12"].fillna(False).astype("int32")
         for column in df.columns:
             df[column] = df[column].fillna(np.dtype(str(df[column].dtype)).type(-1))
-        t1 = default_timer()
+        t1 = timer()
         self.t_fillna += t1 - t0
 
         return df
 
-    def train_daal(self, pd_df):
+    def train_daal(self, x, y):
         import daal4py
 
         dxgb_daal_params = {
@@ -461,21 +340,21 @@ class MortgagePandasBenchmark:
             "memorySavingMode": False,
         }
 
-        t0 = default_timer()
-        y = np.ascontiguousarray(pd_df["delinquency_12"], dtype=np.float32).reshape(len(pd_df), 1)
-        x = np.ascontiguousarray(pd_df.drop(["delinquency_12"], axis=1), dtype=np.float32)
-        t1 = default_timer()
+        t0 = timer()
+        y = np.ascontiguousarray(y, dtype=np.float32).reshape(len(pd_df), 1)
+        x = np.ascontiguousarray(x, dtype=np.float32)
+        t1 = timer()
         self.t_dmatrix = t1 - t0
         # print("Convert x,y from 64 to 32:", t1-t0)
 
         train_algo = daal4py.gbt_regression_training(**dxgb_daal_params)
-        t0 = default_timer()
+        t0 = timer()
         train_result = train_algo.compute(x, y)
-        self.t_train = default_timer() - t0
-        # print("TRAINING TIME:", default_timer()-t0)
+        self.t_train = timer() - t0
+        # print("TRAINING TIME:", timer()-t0)
         return train_result
 
-    def train_xgb(self, pd_df):
+    def train_xgb(self, x, y):
         import xgboost as xgb
 
         dxgb_cpu_params = {
@@ -494,26 +373,29 @@ class MortgagePandasBenchmark:
             "predictor": "cpu_predictor",
         }
 
-        t0 = default_timer()
-        y = pd_df["delinquency_12"]
-        x = pd_df.drop(["delinquency_12"], axis=1)
-        t1 = default_timer()
-        self.t_drop_cols += t1 - t0
-
+        t1 = timer()
         dtrain = xgb.DMatrix(x, y)
-        self.t_dmatrix = default_timer() - t1
+        self.t_dmatrix = timer() - t1
 
-        t0 = default_timer()
+        t0 = timer()
         model_xgb = xgb.train(dxgb_cpu_params, dtrain, num_boost_round=dxgb_cpu_params["nround"])
-        self.t_train = default_timer() - t0
+        self.t_train = timer() - t0
 
         # calculate mse and cod
         x_test = xgb.DMatrix(x)
         y_pred = model_xgb.predict(x_test)
-        self.score_mse = mse(y, y_pred)
-        self.score_cod = cod(y, y_pred)
+        self.score_mse = self.mse(y, y_pred)
+        self.score_cod = self.cod(y, y_pred)
 
         return model_xgb
+
+    def split_cols(self, pd_df):
+        t0 = timer()
+        y = pd_df["delinquency_12"]
+        x = pd_df.drop(["delinquency_12"], axis=1)
+        t1 = timer()
+        self.t_drop_cols += t1 - t0
+        return x, y
 
     @staticmethod
     def mse(y_test, y_pred):
@@ -525,6 +407,67 @@ class MortgagePandasBenchmark:
         total = ((y_test - y_bar) ** 2).sum()
         residuals = ((y_test - y_pred) ** 2).sum()
         return 1 - (residuals / total)
+
+    @staticmethod
+    def split_year_quarter(num):
+        return 2000 + num // 4, num % 4 + 1
+
+def etl_pandas(
+    dataset_path,
+    dfiles_num,
+    acq_schema,
+    perf_schema,
+    etl_keys
+):
+    etl_times = {key: 0.0 for key in etl_keys}
+
+    mb = MortgagePandasBenchmark(dataset_path, 'xgb', acq_schema.to_pandas(), perf_schema.to_pandas())
+    year, quarter = MortgagePandasBenchmark.split_year_quarter(dfiles_num)
+    pd_dfs = []
+    for fname in mb.list_perf_files(quarter=quarter, year=year):
+        pd_dfs.append(mb.run_cpu_workflow(quarter=quarter, year=year, perf_file=fname))
+    pd_df = pd_dfs[0] if len(pd_dfs) == 1 else pd.concat(pd_dfs)
+    etl_times["t_readcsv"] = round(mb.t_read_csv * 1000)
+    print("ETL timings")
+    print("  t_one_hot_encoding = ", mb.t_one_hot_encoding)
+    print("  t_fillna = ", mb.t_fillna)
+    print("  t_drop_cols = ", mb.t_drop_cols)
+    print("  t_merge = ", mb.t_merge)
+    print("  t_conv_dates = ", mb.t_conv_dates)
+    x, y = mb.split_cols(pd_df)
+    etl_times["t_etl"] = round((mb.t_one_hot_encoding + mb.t_fillna + mb.t_drop_cols + mb.t_merge + mb.t_conv_dates) * 1000)
+
+    return pd_df, x, y, mb, etl_times
+
+def ml(x, y, mb, ml_keys, ml_score_keys):
+    mse_values, cod_values = [], []
+    ml_times = {key: 0.0 for key in ml_keys}
+    ml_scores = {key: 0.0 for key in ml_score_keys}
+
+    print("ML runs: ", n_runs)
+    for i in range(n_runs):
+        mb.train_xgb(x, y)
+        ml_times['t_train_test_split'] += mb.t_dmatrix
+        ml_times['t_train'] += mb.t_train
+        mse_values.append(mb.score_mse)
+        cod_values.append(mb.score_cod)
+
+    ml_times["t_ml"] += ml_times["t_train"] + ml_times["t_inference"]
+
+    ml_scores["mse_mean"] = sum(mse_values) / len(mse_values)
+    ml_scores["cod_mean"] = sum(cod_values) / len(cod_values)
+    ml_scores["mse_dev"] = pow(
+        sum([(mse_value - ml_scores["mse_mean"]) ** 2 for mse_value in mse_values])
+        / (len(mse_values) - 1),
+        0.5,
+    )
+    ml_scores["cod_dev"] = pow(
+        sum([(cod_value - ml_scores["cod_mean"]) ** 2 for cod_value in cod_values])
+        / (len(cod_values) - 1),
+        0.5,
+    )
+
+    return ml_scores, ml_times
 
 
 def main():
@@ -652,7 +595,7 @@ def main():
     for iii in range(1, args.iterations + 1):
         dataFilesNumber = 0
         pd_dfs = []
-        time_ETL = default_timer()
+        time_ETL = timer()
         mb = MortgagePandasBenchmark(data_directory, args.algo)
         print("RUNNING BENCHMARK NUMBER", benchName, "ITERATION NUMBER", iii)
         for quarter in range(0, args.df):
@@ -670,7 +613,7 @@ def main():
                 )
             dataFilesNumber += 1
 
-        time_ETL = default_timer() - time_ETL
+        time_ETL = timer() - time_ETL
         print("ITERATION", iii, "ETL TIME: ", time_ETL)
 
         if bestExecTime > time_ETL:

--- a/mortgage/mortgage_runner.py
+++ b/mortgage/mortgage_runner.py
@@ -90,7 +90,7 @@ def run_benchmark(parameters):
     )
 
     etl_keys = ["t_readcsv", "t_etl"]
-    ml_keys = ["t_train_test_split", "t_ml", "t_train"]
+    ml_keys = ["t_dmatrix", "t_ml", "t_train"]
     ml_score_keys = ["mse_mean", "cod_mean", "mse_dev", "cod_dev"]
     N_RUNS = 1
 

--- a/mortgage/mortgage_runner.py
+++ b/mortgage/mortgage_runner.py
@@ -1,0 +1,41 @@
+import warnings
+
+from ..utils import (
+    cod,
+    compare_dataframes,
+    import_pandas_into_module_namespace,
+    load_data_pandas,
+    mse,
+    print_results,
+    split,
+)
+
+warnings.filterwarnings("ignore")
+
+def run_benchmark(parameters):
+    '''
+        parameters = {
+            "data_file": args.data_file,
+            "dfiles_num": args.dfiles_num,
+            "no_ml": args.no_ml,
+            "no_ibis": args.no_ibis,
+            "optimizer": args.optimizer,
+            "pandas_mode": args.pandas_mode,
+            "ray_tmpdir": args.ray_tmpdir,
+            "ray_memory": args.ray_memory,
+            "gpu_memory": args.gpu_memory,
+            "validation": False if args.no_ibis else args.validation,
+        }
+    '''
+    ignored_parameters = {
+        "dfiles_num": parameters["dfiles_num"],
+        "gpu_memory": parameters["gpu_memory"],
+    }
+    warnings.warn(f"Parameters {ignored_parameters} are irnored", RuntimeWarning)
+
+    import_pandas_into_module_namespace(
+        namespace=run_benchmark.__globals__,
+        mode=parameters["pandas_mode"],
+        ray_tmpdir=parameters["ray_tmpdir"],
+        ray_memory=parameters["ray_memory"],
+    )

--- a/mortgage/mortgage_runner.py
+++ b/mortgage/mortgage_runner.py
@@ -20,10 +20,10 @@ warnings.filterwarnings("ignore")
 # Dataset link
 # https://rapidsai.github.io/demos/datasets/mortgage-data
 
-def _run_ml(x, y, mb, ml_keys, ml_score_keys, backend):
+def _run_ml(df, n_runs, mb, ml_keys, ml_score_keys, backend):
     ml_scores, ml_times = ml(
-        x=x,
-        y=y,
+        df=df,
+        n_runs=n_runs,
         mb=mb,
         ml_keys=ml_keys,
         ml_score_keys=ml_score_keys,
@@ -88,15 +88,16 @@ def run_benchmark(parameters):
                'float64', 'float64', 'category',
                'float64', 'category')
     )
+
     etl_keys = ["t_readcsv", "t_etl"]
     ml_keys = ["t_train_test_split", "t_ml", "t_train"]
     ml_score_keys = ["mse_mean", "cod_mean", "mse_dev", "cod_dev"]
-
+    N_RUNS = 1
 
     result = {'ETL': [], 'ML': []}
 
     if not parameters['no_ibis']:
-        df_ibis, x_ibis, y_ibis, mb_ibis, etl_times_ibis = etl_ibis(
+        df_ibis, mb_ibis, etl_times_ibis = etl_ibis(
             dataset_path=parameters['data_file'],
             dfiles_num=parameters['dfiles_num'],
             acq_schema=acq_schema,
@@ -114,7 +115,7 @@ def run_benchmark(parameters):
         etl_times_ibis['Backend'] = 'Ibis'
         result['ETL'].append(etl_times_ibis)
         if not parameters['no_ml']:
-            result['ML'].append(_run_ml(x_ibis, y_ibis, mb_ibis, ml_keys, ml_score_keys, 'Ibis'))
+            result['ML'].append(_run_ml(df_ibis, N_RUNS, mb_ibis, ml_keys, ml_score_keys, 'Ibis'))
     
     df_pd, x_pd, y_pd, mb_pd, etl_times_pd = etl_pandas(
         dataset_path=parameters['data_file'],
@@ -128,6 +129,6 @@ def run_benchmark(parameters):
     result['ETL'].append(etl_times_pd)
 
     if not parameters['no_ml']:
-        result['ML'].append(_run_ml(x_pd, y_pd, mb_pd, ml_keys, ml_score_keys, parameters["pandas_mode"]))
+        result['ML'].append(_run_ml(df_pd, N_RUNS, mb_pd, ml_keys, ml_score_keys, parameters["pandas_mode"]))
 
     return result

--- a/mortgage/mortgage_runner.py
+++ b/mortgage/mortgage_runner.py
@@ -42,10 +42,11 @@ def run_benchmark(parameters):
     warnings.warn(f"Parameters {ignored_parameters} are irnored", RuntimeWarning)
     if parameters['validation']:
         print('WARNING: Validation not yet supported')
-    if parameters['import_mode'] not in ('fsi', 'pandas'):
-        raise ValueError('Unsupported import mode: %s' % parameters['import_mode'])
-    if parameters['dfiles_num'] != 1:
-        raise NotImplementedError('Loading more than 1 file not implemented yet')
+    if not parameters['no_ibis']:
+        if parameters['import_mode'] not in ('fsi',):
+            raise ValueError('Unsupported import mode: %s' % parameters['import_mode'])
+        if parameters['dfiles_num'] != 1:
+            raise NotImplementedError('Loading more than 1 file not implemented yet')
     
 
     import_pandas_into_module_namespace(

--- a/mortgage/mortgage_runner.py
+++ b/mortgage/mortgage_runner.py
@@ -117,7 +117,7 @@ def run_benchmark(parameters):
         if not parameters['no_ml']:
             result['ML'].append(_run_ml(df_ibis, N_RUNS, mb_ibis, ml_keys, ml_score_keys, 'Ibis'))
     
-    df_pd, x_pd, y_pd, mb_pd, etl_times_pd = etl_pandas(
+    df_pd, mb_pd, etl_times_pd = etl_pandas(
         dataset_path=parameters['data_file'],
         dfiles_num=parameters['dfiles_num'],
         acq_schema=acq_schema,

--- a/mortgage/mortgage_runner.py
+++ b/mortgage/mortgage_runner.py
@@ -1,5 +1,7 @@
 import warnings
 
+import ibis
+
 from utils import (
     cod,
     compare_dataframes,
@@ -9,8 +11,14 @@ from utils import (
     print_results,
     split,
 )
+from .mortgage_ibis import etl_ibis
 
 warnings.filterwarnings("ignore")
+
+
+# Dataset link
+# https://rapidsai.github.io/demos/datasets/mortgage-data
+
 
 def run_benchmark(parameters):
     '''
@@ -26,12 +34,24 @@ def run_benchmark(parameters):
             "gpu_memory": args.gpu_memory,
             "validation": False if args.no_ibis else args.validation,
         }
+        parameters["database_name"] = args.database_name
+        parameters["table"] = args.table
+        parameters["dnd"] = args.dnd
+        parameters["dni"] = args.dni
+        parameters["import_mode"] = args.import_mode
     '''
+    parameters["data_file"] = parameters["data_file"].replace("'", "")
     ignored_parameters = {
-        "dfiles_num": parameters["dfiles_num"],
         "gpu_memory": parameters["gpu_memory"],
     }
     warnings.warn(f"Parameters {ignored_parameters} are irnored", RuntimeWarning)
+    if parameters['validation']:
+        print('WARNING: Validation not yet supported')
+    if parameters['import_mode'] not in ('fsi', 'pandas'):
+        raise ValueError('Unsupported import mode: %s' % parameters['import_mode'])
+    if parameters['dfiles_num'] != 1:
+        raise NotImplementedError('Loading more than 1 file not implemented yet')
+    
 
     import_pandas_into_module_namespace(
         namespace=run_benchmark.__globals__,
@@ -39,3 +59,61 @@ def run_benchmark(parameters):
         ray_tmpdir=parameters["ray_tmpdir"],
         ray_memory=parameters["ray_memory"],
     )
+
+    acq_schema = ibis.Schema(
+        names=('loan_id', 'orig_channel', 'seller_name', 'orig_interest_rate', 'orig_upb', 'orig_loan_term',
+               'orig_date', 'first_pay_date', 'orig_ltv', 'orig_cltv', 'num_borrowers', 'dti', 'borrower_credit_score',
+               'first_home_buyer', 'loan_purpose', 'property_type', 'num_units', 'occupancy_status', 'property_state',
+               'zip', 'mortgage_insurance_percent', 'product_type', 'coborrow_credit_score', 'mortgage_insurance_type',
+               'relocation_mortgage_indicator', 'year_quarter_ignore'),
+        types=('int64', 'category', 'string', 'float64', 'int64', 'int64',
+               'timestamp', 'timestamp', 'float64', 'float64', 'float64', 'float64', 'float64',
+               'category', 'category', 'category', 'int64', 'category', 'category',
+               'int64', 'float64', 'category', 'float64', 'float64',
+               'category', 'int32')
+    )
+    perf_schema = ibis.Schema(
+        names=("loan_id", "monthly_reporting_period", "servicer", "interest_rate", "current_actual_upb",
+               "loan_age", "remaining_months_to_legal_maturity", "adj_remaining_months_to_maturity",
+               "maturity_date", "msa", "current_loan_delinquency_status", "mod_flag", "zero_balance_code",
+               "zero_balance_effective_date", "last_paid_installment_date", "foreclosed_after",
+               "disposition_date", "foreclosure_costs", "prop_preservation_and_repair_costs",
+               "asset_recovery_costs", "misc_holding_expenses", "holding_taxes", "net_sale_proceeds",
+               "credit_enhancement_proceeds", "repurchase_make_whole_proceeds", "other_foreclosure_proceeds",
+               "non_interest_bearing_upb", "principal_forgiveness_upb", "repurchase_make_whole_proceeds_flag",
+               "foreclosure_principal_write_off_amount", "servicing_activity_indicator"),
+        types=('int64', 'timestamp', 'category', 'float64', 'float64',
+               'float64', 'float64', 'float64',
+               'timestamp', 'float64', 'int32', 'category', 'category',
+               'timestamp', 'timestamp', 'timestamp',
+               'timestamp', 'float64', 'float64',
+               'float64', 'float64', 'float64', 'float64',
+               'float64', 'float64', 'float64',
+               'float64', 'float64', 'category',
+               'float64', 'category')
+    )
+    etl_keys = ["t_readcsv", "t_etl"]
+
+
+    result = {'ETL': [], 'ML': []}
+
+    if not parameters['no_ibis']:
+        df_ibis, x_ibis, y_ibis, etl_times_ibis = etl_ibis(
+            dataset_path=parameters['data_file'],
+            dfiles_num=parameters['dfiles_num'],
+            acq_schema=acq_schema,
+            perf_schema=perf_schema,
+            database_name=parameters['database_name'],
+            table_prefix=parameters['table'],
+            omnisci_server_worker=parameters['omnisci_server_worker'],
+            delete_old_database=not parameters['dnd'],
+            create_new_table=not parameters['dni'],
+            ipc_connection=parameters['ipc_connection'],
+            etl_keys=etl_keys,
+            import_mode=parameters['import_mode']
+        )
+        print_results(results=etl_times_ibis, backend='Ibis', unit='ms')
+        etl_times_ibis['Backend'] = 'Ibis'
+        result['ETL'].append(etl_times_ibis)
+
+    return result

--- a/mortgage/mortgage_runner.py
+++ b/mortgage/mortgage_runner.py
@@ -1,6 +1,6 @@
 import warnings
 
-from ..utils import (
+from utils import (
     cod,
     compare_dataframes,
     import_pandas_into_module_namespace,

--- a/mortgage/transform-data.py
+++ b/mortgage/transform-data.py
@@ -1,0 +1,57 @@
+import re
+import os
+import sys
+import errno
+import shutil
+
+HEADERS = [
+    'loan_id,orig_channel,seller_name,orig_interest_rate,orig_upb,orig_loan_term,orig_date,first_pay_date,orig_ltv,orig_cltv,num_borrowers,dti,borrower_credit_score,first_home_buyer,loan_purpose,property_type,num_units,occupancy_status,property_state,zip,mortgage_insurance_percent,product_type,coborrow_credit_score,mortgage_insurance_type,relocation_mortgage_indicator,year_quarter_ignore',
+    'loan_id,monthly_reporting_period,servicer,interest_rate,current_actual_upb,loan_age,remaining_months_to_legal_maturity,adj_remaining_months_to_maturity,maturity_date,msa,current_loan_delinquency_status,mod_flag,zero_balance_code,zero_balance_effective_date,last_paid_installment_date,foreclosed_after,disposition_date,foreclosure_costs,prop_preservation_and_repair_costs,asset_recovery_costs,misc_holding_expenses,holding_taxes,net_sale_proceeds,credit_enhancement_proceeds,repurchase_make_whole_proceeds,other_foreclosure_proceeds,non_interest_bearing_upb,principal_forgiveness_upb,repurchase_make_whole_proceeds_flag,foreclosure_principal_write_off_amount,servicing_activity_indicator'
+]
+
+def main():
+    headers = {h.count(','): h for h in HEADERS}
+    try:
+        source, dest = [os.path.abspath(x) for x in sys.argv[1:]]
+    except:
+        sys.exit('Usage: %s source-path dest-path' % sys.argv[0])
+    
+    for root, _, files in os.walk(source):
+        if not files:
+            continue
+        targetDir = os.path.join(dest, os.path.relpath(root, source))
+        try:
+            os.makedirs(targetDir)
+        except OSError as err:
+            if err.errno != errno.EEXIST:
+                raise
+        for fn in files:
+            srcFile = os.path.join(root, fn)
+            destFile = os.path.join(targetDir, fn)
+            if not re.match(r'.*\d+Q\d\..*', fn):
+                print('Copying %s as is...' % fn)
+                shutil.copy(srcFile, destFile)
+                continue
+
+            print('Processing %s...\n\tReading' % srcFile)
+            with open(srcFile) as inp:
+                data = inp.read()
+            print('\tReplacing delimiters')
+            data = data.replace(',', '_').replace('|', ',')
+            line = data[:data.find('\n')].strip()
+            try:
+                header = headers[line.count(',')]
+            except KeyError:
+                print('Warning: cannot determine headers for %s' % srcFile)
+                header = None
+            print('\tTransforming dates')
+            data = re.sub(r'(?<=,)(\d+)/(\d+)/(\d+)(?=,)', r'\3-\1-\2', data)
+            data = re.sub(r'(?<=,)(\d+)/(\d+)(?=,)', r'\2-\1-01', data)
+            print('\tWriting output to %s' % destFile)
+            with open(destFile, 'w') as out:
+                if header:
+                    out.write(header + '\n')
+                out.write(data)
+
+if __name__ == '__main__':
+    main()

--- a/run_ibis_benchmark.py
+++ b/run_ibis_benchmark.py
@@ -308,6 +308,7 @@ def main():
                 http_port=args.http_port,
                 calcite_port=args.calcite_port,
                 database_name=args.database_name,
+                omnisci_cwd=args.omnisci_cwd,
                 user=args.user,
                 password=args.password,
                 debug_timer=args.debug_timer,

--- a/run_ibis_benchmark.py
+++ b/run_ibis_benchmark.py
@@ -19,7 +19,13 @@ def main():
     omnisci_server = None
     port_default_value = -1
 
-    benchmarks = ["ny_taxi", "santander", "census", "plasticc"]
+    benchmarks = {
+        "ny_taxi": "taxi",
+        "santander": "santander",
+        "census": "census",
+        "plasticc": "plasticc",
+        "mortgage": "mortgage",
+    }
 
     parser = argparse.ArgumentParser(description="Run internal tests from ibis project")
     optional = parser._action_groups.pop()
@@ -29,7 +35,7 @@ def main():
     required.add_argument(
         "-bench_name",
         dest="bench_name",
-        choices=benchmarks,
+        choices=sorted(benchmarks.keys()),
         help="Benchmark name.",
         required=True,
     )
@@ -276,14 +282,7 @@ def main():
         if args.calcite_port == port_default_value:
             args.calcite_port = find_free_port()
 
-        if args.bench_name == "ny_taxi":
-            from taxi import run_benchmark
-        elif args.bench_name == "santander":
-            from santander import run_benchmark
-        elif args.bench_name == "census":
-            from census import run_benchmark
-        elif args.bench_name == "plasticc":
-            from plasticc import run_benchmark
+        run_benchmark = __import__(benchmarks[args.bench_name]).run_benchmark
 
         parameters = {
             "data_file": args.data_file,

--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -16,7 +16,7 @@ def main():
     port_default_value = -1
 
     parser = argparse.ArgumentParser(description="Run internal tests from ibis project")
-    required = parser._action_groups.pop()
+    required = parser.add_argument_group("common")
     optional = parser.add_argument_group("optional arguments")
     omnisci = parser.add_argument_group("omnisci")
     benchmark = parser.add_argument_group("benchmark")
@@ -24,7 +24,7 @@ def main():
     commits = parser.add_argument_group("commits")
 
     possible_tasks = ["build", "test", "benchmark"]
-    benchmarks = ["ny_taxi", "santander", "census", "plasticc"]
+    benchmarks = ["ny_taxi", "santander", "census", "plasticc", "mortgage"]
 
     # Task
     required.add_argument(

--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -94,7 +94,7 @@ def main():
         "-executable", dest="executable", required=True, help="Path to omnisci_server executable.",
     )
     omnisci.add_argument(
-        "--omnisci_cwd",
+        "-omnisci_cwd",
         dest="omnisci_cwd",
         help="Path to omnisci working directory. "
         "By default parent directory of executable location is used. "

--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -491,7 +491,7 @@ def main():
                     pure_arg = re.sub(r"^--*", "", arg_name)
                     if pure_arg in possible_benchmark_args:
                         arg_value = args_dict[pure_arg]
-                        if arg_value:
+                        if arg_value is not None:
                             if type(arg_value) != dict:
                                 benchmark_cmd.extend([arg_name, str(arg_value)])
                             else:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -86,7 +86,10 @@ def import_pandas_into_module_namespace(namespace, mode, ray_tmpdir=None, ray_me
         else:
             raise ValueError(f"Unknown pandas mode {mode}")
         import modin.pandas as pd
-    namespace["pd"] = pd
+    if not isinstance(namespace, (list, tuple)):
+        namespace = [namespace]
+    for space in namespace:
+        space["pd"] = pd
 
 
 def equal_dfs(ibis_dfs, pandas_dfs):


### PR DESCRIPTION
Current limitations:
* `-import_mode` - only `fsi` is supported
* `-dfiles_num` must be 1 for Ibis part
* No validation is performed

Parameters are interpreted as follows:
* `-data_file`: path to the _directory_ containing Mortgage data
* `-dfiles_num`: how many quarters to load
* `-table`: _prefix_ of tables to be made in OmniSci

Ibis version requires `-omnisci_run_kwargs enable-union=1` to be set.

Best performance is achieved with flags `-columnar_output True -lazy_fetch False -multifrag_rs True`.

Currently required branches of components are:
* OmniSci: https://github.com/intel-go/omniscidb/tree/ienkovich/develop-merged-with-master
* Ibis: https://github.com/intel-go/ibis/tree/vnlitvinov/enable-union

I think validation could be added in a separate PR.