### PR TITLE
Omniscripts commit hash reporting to the MySQL database

### DIFF
--- a/run_ibis_benchmark.py
+++ b/run_ibis_benchmark.py
@@ -289,6 +289,12 @@ def main():
         default="1234567890123456789012345678901234567890",
         help="Ibis commit hash to use for benchmark.",
     )
+    optional.add_argument(
+        "-commit_omniscripts",
+        dest="commit_omniscripts",
+        default="1234567890123456789012345678901234567890",
+        help="Omniscripts commit hash to use for tests.",
+    )
 
     try:
         os.environ["PYTHONIOENCODING"] = "UTF-8"
@@ -411,6 +417,7 @@ def main():
                     reporting_init_fields = {
                         "OmnisciCommitHash": args.commit_omnisci,
                         "IbisCommitHash": args.commit_ibis,
+                        "OmniscriptsCommitHash": args.commit_omniscripts,
                     }
 
                     reporting_fields_benchmark_etl = {

--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -339,6 +339,12 @@ def main():
         default="1234567890123456789012345678901234567890",
         help="Ibis commit hash to use for tests.",
     )
+    commits.add_argument(
+        "-commit_omniscripts",
+        dest="commit_omniscripts",
+        default="1234567890123456789012345678901234567890",
+        help="Omniscripts commit hash to use for tests.",
+    )
 
     try:
         args = parser.parse_args()
@@ -500,6 +506,7 @@ def main():
                 "multifrag_rs",
                 "fragments_size",
                 "omnisci_run_kwargs",
+                "commit_omniscripts",
             ]
             args_dict = vars(args)
             args_dict["data_file"] = f"'{args_dict['data_file']}'"


### PR DESCRIPTION
Allows to create omniscripts commit hash dependencies graphs in Grafana. 