### PR TITLE
ipc_conn not forwarding bug fix

### DIFF
--- a/run_ibis_benchmark.py
+++ b/run_ibis_benchmark.py
@@ -225,7 +225,7 @@ def main():
     )
     optional.add_argument(
         "-ipc_conn",
-        dest="ipc_connection",
+        dest="ipc_conn",
         default=True,
         type=str_arg_to_bool,
         help="Table name name to use in omniscidb server.",
@@ -367,7 +367,7 @@ def main():
 
                 omnisci_server_worker = OmnisciServerWorker(omnisci_server)
                 parameters["omnisci_server_worker"] = omnisci_server_worker
-                parameters["ipc_connection"] = args.ipc_connection
+                parameters["ipc_connection"] = args.ipc_conn
                 omnisci_server.launch()
 
             result = run_benchmark(parameters)

--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -144,7 +144,7 @@ def main():
     )
     omnisci.add_argument(
         "-ipc_conn",
-        dest="ipc_connection",
+        dest="ipc_conn",
         default=True,
         type=str_arg_to_bool,
         help="Connection type for ETL operations",
@@ -488,7 +488,7 @@ def main():
                 "calcite_port",
                 "user",
                 "password",
-                "ipc_connection",
+                "ipc_conn",
                 "database_name",
                 "table",
                 "commit_omnisci",


### PR DESCRIPTION
ipc_conn flag is not forwarded from run_ibis_tests to run_ibis_benchmark