### PR TITLE
unique tmp files

### DIFF
--- a/census/census_pandas_ibis.py
+++ b/census/census_pandas_ibis.py
@@ -16,6 +16,7 @@ from utils import (
     mse,
     print_results,
     split,
+    get_tmp_file,
 )
 
 warnings.filterwarnings("ignore")
@@ -156,7 +157,7 @@ def etl_ibis(
                 if filename.endswith("gz"):
                     import gzip
 
-                    unzip_name = "/tmp/census-fsi.csv"
+                    unzip_name = get_tmp_file("census-fsi.csv")
 
                     with gzip.open(filename, "rb") as gz_input:
                         with open(unzip_name, "wb") as output:

--- a/census/census_pandas_ibis.py
+++ b/census/census_pandas_ibis.py
@@ -16,7 +16,7 @@ from utils import (
     mse,
     print_results,
     split,
-    get_tmp_file,
+    get_tmp_filepath,
 )
 
 warnings.filterwarnings("ignore")
@@ -157,7 +157,7 @@ def etl_ibis(
                 if filename.endswith("gz"):
                     import gzip
 
-                    unzip_name = get_tmp_file("census-fsi.csv")
+                    unzip_name = get_tmp_filepath("census-fsi.csv")
 
                     with gzip.open(filename, "rb") as gz_input:
                         with open(unzip_name, "wb") as output:

--- a/santander/santander_pandas_ibis.py
+++ b/santander/santander_pandas_ibis.py
@@ -15,6 +15,7 @@ from utils import (
     load_data_pandas,
     mse,
     print_results,
+    get_tmp_file,
 )
 
 warnings.filterwarnings("ignore")
@@ -130,7 +131,7 @@ def etl_ibis(
                 if filename.endswith(".gz"):
                     import gzip
 
-                    unzip_name = "/tmp/santander-fsi.csv"
+                    unzip_name = get_tmp_file("santander-fsi.csv")
 
                     with gzip.open(filename, "rb") as gz_input:
                         with open(unzip_name, "wb") as output:

--- a/santander/santander_pandas_ibis.py
+++ b/santander/santander_pandas_ibis.py
@@ -15,7 +15,7 @@ from utils import (
     load_data_pandas,
     mse,
     print_results,
-    get_tmp_file,
+    get_tmp_filepath,
 )
 
 warnings.filterwarnings("ignore")
@@ -131,7 +131,7 @@ def etl_ibis(
                 if filename.endswith(".gz"):
                     import gzip
 
-                    unzip_name = get_tmp_file("santander-fsi.csv")
+                    unzip_name = get_tmp_filepath("santander-fsi.csv")
 
                     with gzip.open(filename, "rb") as gz_input:
                         with open(unzip_name, "wb") as output:

--- a/taxi/taxibench_pandas_ibis.py
+++ b/taxi/taxibench_pandas_ibis.py
@@ -353,7 +353,7 @@ def etl_ibis(
                         f"taxibench-{files_limit}-files-fsi.csv", data_file_tmp_dir
                     )
 
-            if data_file_path and not os.path.exists(data_file_path):
+            if data_file_tmp_dir:
                 try:
                     for file_name in data_files_names[:files_limit]:
                         write_to_csv_by_chunks(

--- a/taxi/taxibench_pandas_ibis.py
+++ b/taxi/taxibench_pandas_ibis.py
@@ -13,11 +13,10 @@ from utils import (  # noqa: F401 ("compare_dataframes" imported, but unused. Us
     load_data_pandas,
     print_results,
     write_to_csv_by_chunks,
-    get_dir,
     get_ny_taxi_dataset_size,
     check_support,
     get_tmp_filepath,
-    files_combiner,
+    FilesCombiner,
 )
 
 
@@ -329,7 +328,7 @@ def etl_ibis(
             etl_results["t_connect"] = omnisci_server_worker.get_conn_creation_time()
 
         elif import_mode == "fsi":
-            with files_combiner(
+            with FilesCombiner(
                 data_files_names=data_files_names,
                 combined_filename=f"taxibench-{files_limit}--files-fsi.csv",
                 files_limit=files_limit,

--- a/taxi/taxibench_pandas_ibis.py
+++ b/taxi/taxibench_pandas_ibis.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import traceback
 from timeit import default_timer as timer
@@ -18,6 +17,7 @@ from utils import (  # noqa: F401 ("compare_dataframes" imported, but unused. Us
     get_ny_taxi_dataset_size,
     check_support,
     get_tmp_file,
+    files_combiner,
 )
 
 
@@ -329,53 +329,21 @@ def etl_ibis(
             etl_results["t_connect"] = omnisci_server_worker.get_conn_creation_time()
 
         elif import_mode == "fsi":
-            data_file_path = None
-            data_file_tmp_dir = None
-            # If data files are compressed or number of csv files is more than one,
-            # data files (or single compressed file) should be transformed to single csv file.
-            # Before files transformation, script checks existance of already transformed file
-            # in the directory passed with -data_file flag, and then, if file is not found,
-            # in the omniscripts/tmp directory.
-            if data_files_extension == "gz" or len(data_files_names) > 1:
-                data_file_path = os.path.abspath(
-                    os.path.join(
-                        os.path.dirname(data_files_names[0]),
-                        f"taxibench-{files_limit}-files-fsi.csv",
-                    )
+            with files_combiner(
+                data_files_names=data_files_names,
+                combined_filename=f"taxibench-{files_limit}--files-fsi.csv",
+                files_limit=files_limit,
+            ) as data_file_path:
+                t0 = timer()
+                omnisci_server_worker.get_conn().create_table_from_csv(
+                    table_name,
+                    data_file_path,
+                    schema_table,
+                    header=False,
+                    fragment_size=fragments_size[0],
                 )
-                if not os.path.exists(data_file_path):
-                    data_file_tmp_dir = os.path.join(get_dir("repository_root"), "tmp")
-
-                    if not os.path.exists(data_file_tmp_dir):
-                        os.mkdir(data_file_tmp_dir)
-
-                    data_file_path = get_tmp_file(
-                        f"taxibench-{files_limit}-files-fsi.csv", data_file_tmp_dir
-                    )
-
-            if data_file_tmp_dir:
-                try:
-                    for file_name in data_files_names[:files_limit]:
-                        write_to_csv_by_chunks(
-                            file_to_write=file_name, output_file=data_file_path, write_mode="ab",
-                        )
-                except Exception as exc:
-                    os.remove(data_file_path)
-                    raise exc
-
-            t0 = timer()
-            omnisci_server_worker.get_conn().create_table_from_csv(
-                table_name,
-                data_file_path if data_file_path else data_files_names[0],
-                schema_table,
-                header=False,
-                fragment_size=fragments_size[0],
-            )
-            etl_results["t_readcsv"] += timer() - t0
-            etl_results["t_connect"] = omnisci_server_worker.get_conn_creation_time()
-
-            if data_file_tmp_dir is not None:
-                os.remove(data_file_path)
+                etl_results["t_readcsv"] += timer() - t0
+                etl_results["t_connect"] = omnisci_server_worker.get_conn_creation_time()
 
     # Second connection - this is ibis's ipc connection for DML
     omnisci_server_worker.connect_to_server(database_name, ipc=ipc_connection)

--- a/taxi/taxibench_pandas_ibis.py
+++ b/taxi/taxibench_pandas_ibis.py
@@ -16,7 +16,7 @@ from utils import (  # noqa: F401 ("compare_dataframes" imported, but unused. Us
     get_dir,
     get_ny_taxi_dataset_size,
     check_support,
-    get_tmp_file,
+    get_tmp_filepath,
     files_combiner,
 )
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -18,4 +18,5 @@ from .utils import (
     get_dir,
     get_ny_taxi_dataset_size,
     get_tmp_file,
+    files_combiner,
 )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -17,4 +17,5 @@ from .utils import (
     write_to_csv_by_chunks,
     get_dir,
     get_ny_taxi_dataset_size,
+    get_tmp_file,
 )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -17,6 +17,6 @@ from .utils import (
     write_to_csv_by_chunks,
     get_dir,
     get_ny_taxi_dataset_size,
-    get_tmp_file,
+    get_tmp_filepath,
     files_combiner,
 )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -15,8 +15,8 @@ from .utils import (
     remove_fields_from_dict,
     convert_units,
     write_to_csv_by_chunks,
-    get_dir,
+    create_dir,
     get_ny_taxi_dataset_size,
     get_tmp_filepath,
-    files_combiner,
+    FilesCombiner,
 )

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -7,7 +7,8 @@ from tempfile import mkstemp
 
 conversions = {"ms": 1000, "s": 1, "m": 1 / 60, "": 1}
 repository_root_directory = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-directories = {"repository_root": repository_root_directory}
+temporary_directory = os.path.abspath(os.path.join(repository_root_directory, "tmp"))
+directories = {"repository_root": repository_root_directory, "tmp": temporary_directory}
 ny_taxi_data_files_sizes_MB = OrderedDict(
     {
         "trips_xaa.csv": 8000,
@@ -365,15 +366,67 @@ def check_support(current_params, unsupported_params):
 
 def get_dir(dir_id):
     try:
-        return directories[dir_id]
+        directory = directories[dir_id]
     except KeyError:
         raise ValueError(f"{dir_id} is not known")
+    if not os.path.exists(directory):
+        os.mkdir(directory)
+    return directory
 
 
 def get_ny_taxi_dataset_size(dfiles_num):
     return sum(list(ny_taxi_data_files_sizes_MB.values())[:dfiles_num])
 
 
-def get_tmp_file(filename, dir=None):
+def get_tmp_file(filename, tmp_dir=None):
+    if tmp_dir is None:
+        tmp_dir = get_dir("tmp")
+
     filename, extension = os.path.splitext(filename)
-    return mkstemp(suffix=extension, prefix=filename + "-", dir=dir)[1]
+    file_descriptor, file_path = mkstemp(suffix=extension, prefix=filename + "-", dir=tmp_dir)
+    os.close(file_descriptor)
+
+    return file_path
+
+
+class files_combiner:
+    """
+        If data files are compressed or number of csv files is more than one,
+        data files (or single compressed file) should be transformed to single csv file.
+        Before files transformation, script checks existance of already transformed file
+        in the directory passed with -data_file flag.
+    """
+
+    def __init__(self, data_files_names, combined_filename, files_limit):
+        self._data_files_names = data_files_names
+        self._files_limit = files_limit
+
+        data_file_path = self._data_files_names[0]
+
+        _, data_files_extension = os.path.splitext(data_file_path)
+        if data_files_extension == "gz" or len(data_files_names) > 1:
+            data_file_path = os.path.abspath(
+                os.path.join(os.path.dirname(data_files_names[0]), combined_filename)
+            )
+
+        self._should_combine = not os.path.exists(data_file_path)
+        if self._should_combine:
+            data_file_path = get_tmp_file(combined_filename)
+
+        self._data_file_path = data_file_path
+
+    def __enter__(self):
+        if self._should_combine:
+            for file_name in self._data_files_names[: self._files_limit]:
+                write_to_csv_by_chunks(
+                    file_to_write=file_name, output_file=self._data_file_path, write_mode="ab",
+                )
+
+        return self._data_file_path
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._should_combine:
+            try:
+                os.remove(self._data_file_path)
+            except Exception:
+                pass

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -378,11 +378,13 @@ def get_ny_taxi_dataset_size(dfiles_num):
     return sum(list(ny_taxi_data_files_sizes_MB.values())[:dfiles_num])
 
 
-def get_tmp_file(filename, tmp_dir=None):
+def get_tmp_filepath(filename, tmp_dir=None):
     if tmp_dir is None:
         tmp_dir = get_dir("tmp")
 
     filename, extension = os.path.splitext(filename)
+
+    # filename would be transormed like "census-fsi.csv" -> "ROOT_RESOPOSITORY_DIR/tmp/census-fsi-f15cxc9y.csv"
     file_descriptor, file_path = mkstemp(suffix=extension, prefix=filename + "-", dir=tmp_dir)
     os.close(file_descriptor)
 
@@ -411,7 +413,7 @@ class files_combiner:
 
         self._should_combine = not os.path.exists(data_file_path)
         if self._should_combine:
-            data_file_path = get_tmp_file(combined_filename)
+            data_file_path = get_tmp_filepath(combined_filename)
 
         self._data_file_path = data_file_path
 
@@ -428,5 +430,5 @@ class files_combiner:
         if self._should_combine:
             try:
                 os.remove(self._data_file_path)
-            except Exception:
+            except FileNotFoundError:
                 pass

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -7,8 +7,7 @@ from tempfile import mkstemp
 
 conversions = {"ms": 1000, "s": 1, "m": 1 / 60, "": 1}
 repository_root_directory = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-temporary_directory = os.path.abspath(os.path.join(repository_root_directory, "tmp"))
-directories = {"repository_root": repository_root_directory, "tmp": temporary_directory}
+directories = {"repository_root": repository_root_directory}
 ny_taxi_data_files_sizes_MB = OrderedDict(
     {
         "trips_xaa.csv": 8000,
@@ -364,13 +363,11 @@ def check_support(current_params, unsupported_params):
         warnings.warn(f"Parameters {ignored_params} are ignored", RuntimeWarning)
 
 
-def get_dir(dir_id):
-    try:
-        directory = directories[dir_id]
-    except KeyError:
-        raise ValueError(f"{dir_id} is not known")
+def create_dir(dir_name):
+    directory = os.path.abspath(os.path.join(directories["repository_root"], dir_name))
     if not os.path.exists(directory):
         os.mkdir(directory)
+
     return directory
 
 
@@ -380,7 +377,7 @@ def get_ny_taxi_dataset_size(dfiles_num):
 
 def get_tmp_filepath(filename, tmp_dir=None):
     if tmp_dir is None:
-        tmp_dir = get_dir("tmp")
+        tmp_dir = create_dir("tmp")
 
     filename, extension = os.path.splitext(filename)
 
@@ -391,7 +388,7 @@ def get_tmp_filepath(filename, tmp_dir=None):
     return file_path
 
 
-class files_combiner:
+class FilesCombiner:
     """
         If data files are compressed or number of csv files is more than one,
         data files (or single compressed file) should be transformed to single csv file.

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -374,6 +374,6 @@ def get_ny_taxi_dataset_size(dfiles_num):
     return sum(list(ny_taxi_data_files_sizes_MB.values())[:dfiles_num])
 
 
-def get_tmp_file(filename):
+def get_tmp_file(filename, dir=None):
     filename, extension = os.path.splitext(filename)
-    return mkstemp(extension, filename + "-")[1]
+    return mkstemp(suffix=extension, prefix=filename + "-", dir=dir)[1]

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -3,6 +3,7 @@ import os
 import warnings
 from timeit import default_timer as timer
 from collections import OrderedDict
+from tempfile import mkstemp
 
 conversions = {"ms": 1000, "s": 1, "m": 1 / 60, "": 1}
 repository_root_directory = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -371,3 +372,8 @@ def get_dir(dir_id):
 
 def get_ny_taxi_dataset_size(dfiles_num):
     return sum(list(ny_taxi_data_files_sizes_MB.values())[:dfiles_num])
+
+
+def get_tmp_file(filename):
+    filename, extension = os.path.splitext(filename)
+    return mkstemp(extension, filename + "-")[1]


### PR DESCRIPTION
- now all temporary files should be created via added `get_tmp_filepath` it creates temporary file with the specified name and UID suffix at `repository_root/tmp`. User of `get_tmp_filepath` is responsible for deleting that file
- files combining at Taxi were taken out in a separate class `FilesCombiner`
- `get_dir` were reformated to `create_dir`, with that function you create or get existing directory at the root of repository